### PR TITLE
Enable keyboard sorting for table headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,11 +170,11 @@
     <table id="tbl">
       <thead>
           <tr>
-            <th>Spot</th>
-            <th>Dist / Time</th>
-            <th>Water</th>
-            <th>Season</th>
-            <th>Skill</th>
+            <th class="sortable" tabindex="0" role="button">Spot</th>
+            <th class="sortable" tabindex="0" role="button">Dist / Time</th>
+            <th class="sortable" tabindex="0" role="button">Water</th>
+            <th class="sortable" tabindex="0" role="button">Season</th>
+            <th class="sortable" tabindex="0" role="button">Skill</th>
           </tr>
       </thead>
       <tbody id="spotsBody"></tbody>
@@ -543,6 +543,15 @@ function setOrigin(lat,lng,label){
     filterBox = document.getElementById('filterBox');
     headerEl = document.querySelector('header');
     toTop = document.getElementById('toTop');
+    document.querySelectorAll('th.sortable').forEach(th => {
+      th.addEventListener('keydown', e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          th.click();
+        }
+      });
+    });
+
 
   function updateHeaderOffset(){
     document.documentElement.style.setProperty('--header-h', headerEl.offsetHeight + 'px');


### PR DESCRIPTION
## Summary
- Mark sortable table headers as interactive elements with `tabindex="0"` and `role="button"`
- Add keyboard handlers so Enter and Space trigger the existing sort behavior

## Testing
- ⚠️ `npm test` *(npm: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f995a4ca08330940bbf58ef6584b9