### PR TITLE
Improve mobile detail layout and map view

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -100,7 +100,7 @@
   .muted{color:var(--muted)}
     .pill{display:inline-block;background:var(--control-border);border:1px solid var(--badge-border);color:var(--text);padding:2px 8px;border-radius:999px;margin-right:6px;font-size:12px}
     .hint{font-size:12px;color:var(--muted)}
-    td.detail{padding:16px;font-size:14px}
+    td.detail{padding:16px;font-size:14px;position:relative}
     td.detail p{margin:6px 0}
     .detail-grid{display:flex;gap:16px;align-items:flex-start}
     .detail-grid .img-box{flex:1 1 250px;max-width:300px;position:sticky;top:0}


### PR DESCRIPTION
## Summary
- Keep detail rows within viewport and fix their position while table remains horizontally scrollable
- Hide Leaflet map on small screens when showing location details and restore it when closed

## Testing
- `npx eslint js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a122cfcc108330b83d5e2540b85c63