### PR TITLE
Improve mobile detail view and add filter label

### DIFF
--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -191,12 +191,16 @@
 }
 
 @media (max-width:700px){
-  #selectedWrap .mini-map{width:100%;}
+  #selectedWrap td.detail{padding:0;}
+  #selectedWrap .detail-grid{flex-direction:column;}
+  #selectedWrap .detail-grid .img-box{max-width:100%;position:static;}
+  #selectedWrap .detail-grid .info{padding:16px;}
+  #selectedWrap .mini-map{width:100%;border-radius:0;}
 }
 
 @media (min-width:700px){
   #mapView{position:relative;}
-  #selectedWrap{position:absolute;left:0;right:0;bottom:0;max-height:60%;pointer-events:none;transform:translateY(100%);transition:transform .3s;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);border-radius:var(--radius) var(--radius) 0 0;border:1px solid var(--table-border);border-bottom:0;}
+  #selectedWrap{position:absolute;left:0;right:0;bottom:0;max-height:60%;pointer-events:none;transform:translateY(100%);transition:transform .3s;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);border-radius:var(--radius) var(--radius) 0 0;border:1px solid var(--table-border);border-bottom:0;z-index:10;}
   #selectedTop{background:transparent;}
   #selectedDetail table{background:transparent;}
   #selectedWrap.show{transform:translateY(0);pointer-events:auto;}

--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -193,9 +193,13 @@
 @media (max-width:700px){
   #selectedWrap td.detail{padding:0;}
   #selectedWrap .detail-grid{flex-direction:column;}
-  #selectedWrap .detail-grid .img-box{max-width:100%;position:static;}
+  #selectedWrap .detail-grid .img-box{max-width:100%;position:static;flex:none;width:100%;}
   #selectedWrap .detail-grid .info{padding:16px;}
   #selectedWrap .mini-map{width:100%;border-radius:0;}
+}
+
+@media (max-width:700px){
+  #mapView{margin-left:calc(-1*clamp(16px,4vw,32px));margin-right:calc(-1*clamp(16px,4vw,32px));}
 }
 
 @media (min-width:700px){

--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -171,12 +171,7 @@
 #mapView.hide-map #map{display:none;}
 #mapView.hide-map #selectedWrap{flex:1;}
 #selectedWrap{display:flex;flex-direction:column;flex:1;border:1px solid var(--table-border);border-radius:var(--radius);overflow:hidden;}
-#selectedWrap.map-top #selectedTop{position:relative;display:block;}
-#selectedWrap.map-top #selectedTopMap{display:block;height:200px;}
-#selectedWrap.map-top #selectedTopScroll{display:none;}
-#selectedWrap.map-top #closeSelected{position:absolute;top:8px;right:8px;background:var(--btn-bg);border-radius:8px;}
 #selectedTop{background:var(--card);border-bottom:1px solid var(--table-border);display:flex;align-items:center;}
-#selectedTopMap{display:none;}
 #selectedTopScroll{flex:1;overflow-x:auto;-webkit-overflow-scrolling:touch;}
 #selectedTopScroll table{border-collapse:separate;border-spacing:0;display:flex;width:fit-content;}
 #selectedTopScroll tbody{display:flex;}
@@ -193,4 +188,16 @@
   #selectedDetail{overflow:auto;}
   #selectedDetail .detail-grid{height:auto;}
   #selectedDetail .detail-grid .info{overflow:visible;}
+}
+
+@media (max-width:700px){
+  #selectedWrap .mini-map{width:100%;}
+}
+
+@media (min-width:700px){
+  #mapView{position:relative;}
+  #selectedWrap{position:absolute;left:0;right:0;bottom:0;max-height:60%;pointer-events:none;transform:translateY(100%);transition:transform .3s;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);border-radius:var(--radius) var(--radius) 0 0;border:1px solid var(--table-border);border-bottom:0;}
+  #selectedTop{background:transparent;}
+  #selectedDetail table{background:transparent;}
+  #selectedWrap.show{transform:translateY(0);pointer-events:auto;}
 }

--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -168,8 +168,15 @@
 
 #mapView{display:flex;flex-direction:column;min-width:100%;padding-top:16px;}
 #map{flex:1;border-radius:var(--radius);border:1px solid var(--table-border);}
+#mapView.hide-map #map{display:none;}
+#mapView.hide-map #selectedWrap{flex:1;}
 #selectedWrap{display:flex;flex-direction:column;flex:1;border:1px solid var(--table-border);border-radius:var(--radius);overflow:hidden;}
+#selectedWrap.map-top #selectedTop{position:relative;display:block;}
+#selectedWrap.map-top #selectedTopMap{display:block;height:200px;}
+#selectedWrap.map-top #selectedTopScroll{display:none;}
+#selectedWrap.map-top #closeSelected{position:absolute;top:8px;right:8px;background:var(--btn-bg);border-radius:8px;}
 #selectedTop{background:var(--card);border-bottom:1px solid var(--table-border);display:flex;align-items:center;}
+#selectedTopMap{display:none;}
 #selectedTopScroll{flex:1;overflow-x:auto;-webkit-overflow-scrolling:touch;}
 #selectedTopScroll table{border-collapse:separate;border-spacing:0;display:flex;width:fit-content;}
 #selectedTopScroll tbody{display:flex;}

--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
             <span class="chip f-skill active b-lvlh" data-value="A">Advanced</span>
           </div>
           <div class="chip-group chip-group-flex">
+            <span class="chip-group-label">Distance:</span>
             <input id="mins" type="range" min="15" max="180" step="5" value="180">
             <span class="hint" id="minsVal">≤ 180 min</span>
           </div>
@@ -89,6 +90,7 @@
                 <tbody id="selectedTopBody"></tbody>
               </table>
             </div>
+            <div id="selectedTopMap" class="hidden"></div>
             <button id="closeSelected" aria-label="Close">✕</button>
           </div>
           <div id="selectedDetail"><table><tbody id="selectedBody"></tbody></table></div>

--- a/index.html
+++ b/index.html
@@ -90,7 +90,6 @@
                 <tbody id="selectedTopBody"></tbody>
               </table>
             </div>
-            <div id="selectedTopMap" class="hidden"></div>
             <button id="closeSelected" aria-label="Close">✕</button>
           </div>
           <div id="selectedDetail"><table><tbody id="selectedBody"></tbody></table></div>

--- a/js/main.1.0.0.js
+++ b/js/main.1.0.0.js
@@ -361,6 +361,7 @@ function showSelected(s){
     selectedWrap.classList.remove('show');
     if(mapView) mapView.classList.add('hide-map');
   }else{
+    selectedWrap.classList.remove('hidden');
     selectedWrap.classList.add('show');
   }
   loadImages();

--- a/js/main.1.0.0.js
+++ b/js/main.1.0.0.js
@@ -890,11 +890,19 @@ function setOrigin(lat,lng,label){
   function updateHeaderOffset(){
     document.documentElement.style.setProperty('--header-h', headerEl.offsetHeight + 'px');
   }
-  function handleResize(){
-    updateHeaderOffset();
-    updateMapHeights();
-    checkShrink();
-  }
+    function handleResize(){
+      updateHeaderOffset();
+      updateMapHeights();
+      checkShrink();
+      if(selectedWrap){
+        if(window.innerWidth>=700){
+          selectedWrap.classList.remove('hidden');
+        }else if(!selectedId){
+          selectedWrap.classList.add('hidden');
+          selectedWrap.classList.remove('show');
+        }
+      }
+    }
   window.addEventListener('resize', handleResize);
   handleResize();
 

--- a/js/main.1.0.0.js
+++ b/js/main.1.0.0.js
@@ -103,7 +103,7 @@ let sortCol = 'dist';
 let originMsg, spotsBody, q, mins, minsVal,
     waterChips, seasonChips, skillChips,  // chip sets
     zip, useGeo, filterToggle, filtersEl, headerEl, toTop, sortArrow, tableWrap,
-    viewToggle, viewWindow, viewSlider, mapView, selectedWrap, selectedTopScroll, selectedTopBody, selectedTopMap, selectedBody, selectedDetail, closeSelected, map,
+    viewToggle, viewWindow, viewSlider, mapView, selectedWrap, selectedTopScroll, selectedTopBody, selectedBody, selectedDetail, closeSelected, map,
     editLocation, locationBox, closeLocation, searchRow;
 let showingMap = false;
 let selectedId = null;
@@ -332,7 +332,7 @@ async function loadImages(){
   }
 }
 
-function showSelected(s, mapTop=false){
+function showSelected(s){
   const temp = document.createElement('tbody');
   temp.innerHTML = rowHTML(s);
   const topRow = temp.querySelector('tr.parent');
@@ -348,32 +348,19 @@ function showSelected(s, mapTop=false){
   if(detail) detail.classList.remove('hide');
   selectedTopBody.innerHTML = '';
   selectedBody.innerHTML = '';
-  if(mapTop){
-    if(selectedTopScroll) selectedTopScroll.style.display='none';
-    if(selectedTopMap){
-      selectedTopMap.innerHTML='';
-      const mapDiv=document.createElement('div');
-      mapDiv.style.height='100%';
-      selectedTopMap.appendChild(mapDiv);
-      createMiniMap(mapDiv, s.lat, s.lng);
-      selectedTopMap.classList.remove('hidden');
-      selectedWrap.classList.add('map-top');
-    }
-  }else{
-    if(topRow) selectedTopBody.appendChild(topRow);
-    if(selectedTopScroll) selectedTopScroll.style.display='';
-    if(selectedTopMap){
-      selectedTopMap.innerHTML='';
-      selectedTopMap.classList.add('hidden');
-    }
-    selectedWrap.classList.remove('map-top');
-  }
+  if(topRow) selectedTopBody.appendChild(topRow);
+  if(selectedTopScroll) selectedTopScroll.style.display='';
   if(detail) selectedBody.appendChild(detail);
   selectedDetail.scrollTop = 0;
   const info = selectedBody.querySelector('.info');
   if(info) info.scrollTop = 0;
-  selectedWrap.classList.remove('hidden');
-  if(window.innerWidth<700 && mapView) mapView.classList.add('hide-map');
+  if(window.innerWidth<700){
+    selectedWrap.classList.remove('hidden');
+    selectedWrap.classList.remove('show');
+    if(mapView) mapView.classList.add('hide-map');
+  }else{
+    selectedWrap.classList.add('show');
+  }
   loadImages();
   updateMapHeights();
 }
@@ -381,15 +368,15 @@ function showSelected(s, mapTop=false){
 function clearSelected(){
   if(selectedId && markers[selectedId]) setMarkerSelected(markers[selectedId], false);
   selectedTopBody.innerHTML='';
-  if(selectedTopMap){
-    selectedTopMap.innerHTML='';
-    selectedTopMap.classList.add('hidden');
-  }
   if(selectedTopScroll) selectedTopScroll.style.display='';
   selectedBody.innerHTML='';
-  selectedWrap.classList.add('hidden');
-  selectedWrap.classList.remove('map-top');
-  if(mapView) mapView.classList.remove('hide-map');
+  if(window.innerWidth<700){
+    selectedWrap.classList.add('hidden');
+    selectedWrap.classList.remove('show');
+    if(mapView) mapView.classList.remove('hide-map');
+  }else{
+    selectedWrap.classList.remove('show');
+  }
   document.querySelectorAll('#tbl tbody tr.parent.open').forEach(o=>{
     o.classList.remove('open');
     const d=o.nextElementSibling;
@@ -795,11 +782,14 @@ function setOrigin(lat,lng,label){
     selectedWrap = document.getElementById('selectedWrap');
     selectedTopScroll = document.getElementById('selectedTopScroll');
     selectedTopBody = document.getElementById('selectedTopBody');
-    selectedTopMap = document.getElementById('selectedTopMap');
     selectedBody = document.getElementById('selectedBody');
     selectedDetail = document.getElementById('selectedDetail');
     closeSelected = document.getElementById('closeSelected');
     tableWrap = document.querySelector('.table-wrap');
+
+    if(selectedWrap && window.innerWidth>=700){
+      selectedWrap.classList.remove('hidden');
+    }
 
     if(closeSelected){
       closeSelected.addEventListener('click', ()=>{
@@ -853,8 +843,8 @@ function setOrigin(lat,lng,label){
           const spot = SPOTS.find(s=>s.id===selectedId);
           if(spot){
             if(markers[selectedId]) setMarkerSelected(markers[selectedId], true);
-            showSelected(spot, openedFromTable);
-            if(!openedFromTable) map.flyTo([spot.lat, spot.lng], 16);
+            showSelected(spot);
+            map.flyTo([spot.lat, spot.lng], 16);
           }
         }else{
           clearSelected();


### PR DESCRIPTION
## Summary
- Hide map on small screens when viewing location details
- Show map within detail card from table on mobile and auto-return to table when closed
- Label distance slider in filters for consistency

## Testing
- `npx eslint js/main.1.0.0.js`
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a12df0ee708330b2da228d6b051247