### PR TITLE
feat: redesign map with regulatory info popup

### DIFF
--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -39,11 +39,10 @@
   .header-row{display:grid;grid-template-columns:auto 1fr auto;align-items:center;column-gap:50px;padding:8px;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px)}
   .settings{justify-self:end;display:flex;align-items:center;gap:8px;position:relative;height:48px}
   .header-row h1{justify-self:start}
-  #filterBtn{background:var(--btn-bg);border:1px solid var(--btn-border);color:var(--text);border-radius:8px;width:48px;height:48px;display:flex;align-items:center;justify-content:center;font-size:24px;cursor:pointer;transform:scaleX(-1)}
   #filterBtn.open{transform:scaleX(-1) rotate(180deg)}
-  #infoBtn{background:var(--btn-bg);border:1px solid var(--btn-border);color:var(--text);border-radius:8px;width:48px;height:48px;display:flex;align-items:center;justify-content:center;font-size:24px;cursor:pointer}
-  #editLocation{font-size:14px;line-height:48px;white-space:nowrap}
-  #locationBox{position:absolute;right:0;top:100%;margin-top:8px;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);border:1px solid var(--table-border);border-radius:var(--radius);padding:8px;display:flex;flex-direction:column;gap:8px;z-index:60}
+  .settings button{background:var(--btn-bg);border:1px solid var(--btn-border);color:var(--text);border-radius:8px;width:48px;height:48px;display:flex;align-items:center;justify-content:center;font-size:24px;cursor:pointer}
+  .settings button.active{background:var(--btn-alt-bg);border-color:var(--accent)}
+  #locationBox{position:absolute;right:0;top:100%;margin-top:8px;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);border:1px solid var(--table-border);border-radius:var(--radius);padding:8px;display:flex;flex-direction:column;gap:8px;z-index:60;min-width:260px}
   #locationBox .loc-row{display:flex;align-items:center;gap:8px}
   #filters{margin-top:8px;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);border-radius:var(--radius);border:1px solid var(--table-border);padding:12px}
   .hidden{display:none!important}
@@ -187,9 +186,10 @@
 #map{position:fixed;top:0;left:0;right:0;bottom:0;z-index:0;}
 #tablePanel{position:fixed;top:calc(var(--header-h) + 8px);left:0;width:var(--panel-w);height:calc(100% - var(--header-h) - 8px);background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);transform:translateX(-100%);transition:transform .3s;z-index:40;border:1px solid var(--table-border);border-left:none;border-top-right-radius:var(--radius);border-bottom-right-radius:var(--radius);padding-top:0;overflow:hidden;display:flex;flex-direction:column;}
 #tablePanel.open{transform:translateX(0);}
+#panelGrip{position:absolute;top:0;right:0;width:8px;height:100%;cursor:col-resize}
 #closePanel{position:absolute;top:8px;right:24px;background:none;border:none;color:var(--muted);cursor:pointer;font-size:24px;z-index:5}
-#selectedWrap{position:fixed;left:0;right:0;top:var(--header-h);bottom:0;z-index:60;transform:translateY(100%);transition:transform .3s;border-top-left-radius:var(--radius);border-top-right-radius:var(--radius);overflow:hidden;border:1px solid var(--table-border);background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);}
-#selectedWrap.show{transform:translateY(0);}
+#selectedWrap{position:fixed;left:50%;top:var(--header-h);bottom:0;width:75%;max-width:800px;z-index:60;transform:translate(-50%,100%);transition:transform .3s,width .3s;border-top-left-radius:var(--radius);border-top-right-radius:var(--radius);overflow:hidden;border:1px solid var(--table-border);background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);display:flex;flex-direction:column;}
+#selectedWrap.show{transform:translate(-50%,0);}
 #selectedTop{background:transparent;border-bottom:1px solid var(--table-border);display:flex;align-items:center;cursor:grab;}
 #selectedTopScroll{flex:1;overflow-x:auto;-webkit-overflow-scrolling:touch;}
 #selectedTopScroll table{border-collapse:separate;border-spacing:0;display:flex;width:fit-content;}
@@ -199,9 +199,8 @@
 #selectedTopScroll .cell-label{font-weight:600;margin-right:4px;color:var(--muted);}
 #closeSelected{background:none;border:none;color:var(--muted);cursor:pointer;padding:8px 12px;font-size:24px;}
 
-#useGeo{font-size:24px;}
 .leaflet-bar a{width:39px;height:39px;line-height:39px;font-size:24px;}
-#selectedDetail{flex:1;overflow:auto;height:calc(100% - 40px);}
+#selectedDetail{flex:1;overflow:auto;}
 #selectedDetail table,#selectedDetail tbody,#selectedDetail tr,#selectedDetail td.detail{height:100%;}
 #selectedDetail table{width:100%;min-width:0;border-collapse:separate;border-spacing:0;background:transparent;}
 #selectedDetail .detail-grid{height:100%;}
@@ -218,6 +217,6 @@ body.panel-open .leaflet-left{left:var(--panel-w);}
 @media (max-width:700px){
   #tablePanel{width:100%;}
   
-  #selectedWrap{top:var(--header-h);bottom:auto;height:calc(100% - var(--header-h));transform:translateY(100%);transition:transform .3s;}
+  #selectedWrap{top:var(--header-h);bottom:auto;height:calc(100% - var(--header-h));width:100%;left:0;transform:translateY(100%);transition:transform .3s,width .3s;}
   #selectedWrap.show{transform:translateY(0);bottom:auto;}
 }

--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -1,6 +1,8 @@
   :root{
     color-scheme: light dark;
     --radius:12px; --hover:rgba(0,0,0,.04);
+    --header-h:0px;
+    --panel-w:50%;
     --bg:#ffffff; --card:#f5f7fa; --muted:#556270; --text:#111; --accent:#0047ab;
     --salt:#4aa6ff; --fresh:#41e36e; --brack:#b07bff;
     --yr:#ffb020; --sprfall:#2fd277; --summer:#ffd24d; --winter:#7dd3fc;
@@ -10,6 +12,7 @@
     --input-bg:#ffffff; --input-border:#d0d7e2; --btn-bg:#e0e4ea; --btn-border:#cfd6e1;
     --btn-alt-bg:#d0e9f1; --btn-alt-border:#bcd3db; --toggle-off:#cfd6e1;
     --header-grad1:rgba(255,255,255,.9); --header-grad2:rgba(255,255,255,.6);
+    --panel-card:rgba(245,247,250,.85);
   }
   @media (prefers-color-scheme: dark){
     :root{
@@ -21,18 +24,28 @@
       --btn-alt-bg:#234a5a; --btn-alt-border:#2f667a;
       --toggle-off:#263044;
       --header-grad1:rgba(14,17,22,.9); --header-grad2:rgba(14,17,22,.6);
+      --panel-card:rgba(21,26,34,.85);
       --ok:#2fd277; --warn:#ffad42; --no:#ff6b6b;
       --hover:rgba(255,255,255,.06);
     }
   }
   html,body{background:var(--bg);color:var(--text);font-family:system-ui,Segoe UI,Inter,Roboto,Arial,sans-serif;font-size:clamp(16px,1.5vw,18px);line-height:1.6;margin:0}
   a{color:var(--accent);text-decoration:none} a:hover{opacity:.9}
-  header{position:sticky;top:0;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);z-index:50}
+  header{position:sticky;top:0;background:none;backdrop-filter:none;z-index:50}
   .wrap{max-width:1200px;margin:auto;padding:clamp(16px,4vw,32px)}
-  header .wrap{padding-top:8px}
+  header .wrap{max-width:none;margin:0;padding:0}
   main.wrap{padding-top:0}
-  h1{margin:8px 0 4px;font-weight:800;font-size:clamp(24px,4vw,40px)}
-  .sub{color:var(--muted);font-size:14px}
+  h1{margin:0;font-weight:800;font-size:clamp(24px,4vw,40px);white-space:nowrap;line-height:48px;height:48px}
+  .header-row{display:grid;grid-template-columns:auto 1fr auto;align-items:center;column-gap:50px;padding:8px;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px)}
+  .settings{justify-self:end;display:flex;align-items:center;gap:8px;position:relative;height:48px}
+  .header-row h1{justify-self:start}
+  #filterBtn{background:var(--btn-bg);border:1px solid var(--btn-border);color:var(--text);border-radius:8px;width:48px;height:48px;display:flex;align-items:center;justify-content:center;font-size:24px;cursor:pointer;transform:scaleX(-1)}
+  #filterBtn.open{transform:scaleX(-1) rotate(180deg)}
+  #infoBtn{background:var(--btn-bg);border:1px solid var(--btn-border);color:var(--text);border-radius:8px;width:48px;height:48px;display:flex;align-items:center;justify-content:center;font-size:24px;cursor:pointer}
+  #editLocation{font-size:14px;line-height:48px;white-space:nowrap}
+  #locationBox{position:absolute;right:0;top:100%;margin-top:8px;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);border:1px solid var(--table-border);border-radius:var(--radius);padding:8px;display:flex;flex-direction:column;gap:8px;z-index:60}
+  #locationBox .loc-row{display:flex;align-items:center;gap:8px}
+  #filters{margin-top:8px;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);border-radius:var(--radius);border:1px solid var(--table-border);padding:12px}
   .hidden{display:none!important}
   .mb-40{margin-bottom:40px}
   details{margin:8px 0}
@@ -63,18 +76,23 @@
   .toggle:checked{background:var(--accent)}
   .toggle:before{content:'';position:absolute;top:3px;left:3px;width:18px;height:18px;background:#fff;border-radius:50%;transition:transform .2s}
   .toggle:checked:before{transform:translateX(18px)}
-  .table-wrap{border:1px solid var(--table-border);border-radius:var(--radius);overflow-x:auto;-webkit-overflow-scrolling:touch;width:100%}
-  .table-wrap table{width:100%;min-width:600px;border-collapse:separate;border-spacing:0;background:var(--card)}
-  .table-wrap thead,.table-wrap tbody tr{display:table;width:100%;table-layout:fixed}
-  .table-wrap tbody{display:block;transition:max-height .6s}
-  .table-wrap.scroll tbody{overflow:auto;overscroll-behavior:contain}
-  .table-wrap thead th{position:sticky;top:var(--header-h);z-index:2;background:var(--card);white-space:nowrap}
-    th,td{padding:12px 14px;border-bottom:1px solid var(--table-border);vertical-align:top;font-size:14px;word-break:break-word;text-align:left}
+  .table-wrap{border:none;border-radius:0;overflow-x:auto;-webkit-overflow-scrolling:touch;width:100%;background:transparent;overflow-y:auto;flex:1}
+  .table-wrap table{width:100%;min-width:600px;border-collapse:separate;border-spacing:0;background:transparent;table-layout:fixed}
+  .table-wrap thead{position:sticky;top:0;z-index:2;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px)}
+  .table-wrap thead th{white-space:nowrap}
+  .c-name{width:40%}
+  .c-dist{width:15%}
+  .c-water{width:15%}
+  .c-season{width:15%}
+  .c-skill{width:15%}
+  .table-wrap tbody{display:table-row-group}
+    th,td{padding:12px 14px;border-bottom:1px solid var(--table-border);vertical-align:top;font-size:14px;word-break:break-word;text-align:left;position:relative}
     tbody tr{transition:background .2s}
     tbody tr.hide{display:none}
     tbody tr.parent{cursor:pointer}
-    tbody tr.detail-row{background:var(--card)}
-    tbody tr:hover{background:var(--hover)}
+    tbody tr.detail-row{background:transparent}
+    .table-wrap tbody tr:hover{background:var(--hover)}
+    #selectedWrap tbody tr:hover{background:transparent}
   th.sortable{cursor:pointer}
   #sortArrow{margin-left:4px}
   .spot{font-weight:700}
@@ -94,7 +112,7 @@
   .lvle{background:var(--easy)} .lvlm{background:var(--med)} .lvlh{background:var(--hard)}
   .pop{white-space:normal}
     .ok{color:var(--ok)} .warn{color:var(--warn)} .no{color:var(--no)}
-    .foot{color:var(--muted);font-size:12px;margin-top:8px}
+  .foot{color:var(--muted);font-size:12px;margin-top:8px}
   section{scroll-margin-top:var(--header-h)}
   .card{background:var(--card);border:1px solid var(--control-border);border-radius:var(--radius);padding:16px;margin:16px 0}
   .law{font-size:13px;color:var(--accent)}
@@ -105,10 +123,10 @@
     .hint{font-size:12px;color:var(--muted)}
     td.detail{padding:16px;font-size:14px}
     td.detail p{margin:6px 0}
-    .detail-grid{display:flex;gap:16px;align-items:flex-start}
-    .detail-grid .img-box{flex:1 1 250px;max-width:300px;position:sticky;top:0}
+  .detail-grid{display:flex;align-items:flex-start}
+  .detail-grid .detail-grip{flex:0 0 8px;cursor:col-resize}
+  .detail-grid .img-box{flex:0 0 300px;max-width:100%;position:sticky;top:0;overflow:hidden}
     .detail-grid .img-box img{width:100%;height:auto;border-radius:8px;display:block}
-    .detail-grid .img-box .mini-map{width:100%;height:300px;border-radius:8px;overflow:hidden}
     .detail-grid .img-box .img-credit{font-size:12px;color:var(--muted);margin-top:4px}
     .detail-grid .img-box .slide{display:none}
     .detail-grid .img-box .slide.active{display:block}
@@ -116,16 +134,18 @@
     .detail-grid .img-box .img-carousel button{position:absolute;top:50%;transform:translateY(-50%);background:rgba(0,0,0,.5);color:#fff;border:none;padding:4px 8px;border-radius:4px;cursor:pointer}
     .detail-grid .img-box .img-carousel button.prev{left:4px}
     .detail-grid .img-box .img-carousel button.next{right:4px}
-    .detail-grid .img-box .media-toggle{display:flex;gap:8px;margin-bottom:8px}
-    .detail-grid .img-box .media-toggle button{flex:1;background:var(--btn-bg);border:1px solid var(--btn-border);color:var(--text);border-radius:4px;cursor:pointer;padding:4px}
-    .detail-grid .img-box .media-toggle button.active{background:var(--btn-alt-bg);border-color:var(--accent)}
     .detail-grid .info{flex:2 1 260px}
     @media (max-width:700px){
       .detail-grid{flex-direction:column}
       .detail-grid .img-box{max-width:100%;position:static}
     }
-    #toTop{position:fixed;right:20px;bottom:20px;padding:10px 12px;border-radius:50%;border:none;background:var(--btn-bg);color:var(--text);box-shadow:0 2px 4px rgba(0,0,0,.2);cursor:pointer;display:none;z-index:100}
+    #toTop{position:fixed;right:20px;bottom:20px;padding:10px 12px;border-radius:50%;border:none;background:var(--btn-bg);color:var(--text);box-shadow:0 2px 4px rgba(0,0,0,.2);cursor:pointer;display:none;z-index:100;font-size:24px}
   #toTop.show{display:block}
+  #siteFooter{position:fixed;bottom:8px;left:8px;color:#fff;font-size:12px;z-index:80;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);padding:4px 8px;border-radius:var(--radius);border:1px solid var(--table-border)}
+  #siteFooter a{color:#fff}
+  #infoPopup{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);max-width:700px;width:90%;max-height:80vh;overflow:auto;z-index:200;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);border:1px solid var(--table-border);border-radius:var(--radius);padding:16px}
+  #infoPopup .info-inner{position:relative}
+  #closeInfo{position:absolute;top:8px;right:8px;background:none;border:none;color:var(--muted);cursor:pointer;font-size:24px}
 @media (max-width:800px){
     #selectedDetail tbody tr{display:block;margin-bottom:12px}
     #selectedDetail tbody td{display:flex;justify-content:space-between;border-bottom:1px dashed var(--table-border);padding:8px 12px}
@@ -140,15 +160,13 @@
 .cite-group{display:inline-block;margin-left:4px;font-size:0.75em;}
 .cite-group a{display:block;color:var(--muted);background:var(--badge);border:1px solid var(--badge-border);border-radius:4px;padding:0 4px;text-decoration:none;}
 
-  #originInfo a,#locationBox{margin-left:8px}
-  #locationBox{display:inline-flex;align-items:center;gap:8px}
-  #closeLocation{background:none;border:none;font-size:16px;cursor:pointer;color:var(--muted);margin-left:4px;padding:4px}
-  #zip{width:100px;background:var(--input-bg);border:1px solid var(--input-border);border-radius:8px;color:var(--text);padding:8px}
-  #useGeo{background:var(--btn-alt-bg);border:1px solid var(--btn-alt-border);color:var(--text);border-radius:8px;padding:8px;cursor:pointer}
-  #searchRow{display:flex;gap:8px;align-items:center;width:100%}
-  #q{flex:1;background:var(--input-bg);border:1px solid var(--input-border);border-radius:8px;color:var(--text);padding:8px}
-  #viewToggle,#filterToggle{background:var(--btn-bg);border:1px solid var(--btn-border);color:var(--text);border-radius:8px;padding:8px;cursor:pointer}
-  #filters{margin-top:8px}
+    #zip{width:100px;background:var(--input-bg);border:1px solid var(--input-border);border-radius:8px;color:var(--text);padding:8px}
+    #useGeo{background:var(--btn-alt-bg);border:1px solid var(--btn-alt-border);color:var(--text);border-radius:8px;padding:8px;cursor:pointer}
+    #q{width:100%;max-width:50%;min-width:0;background:rgba(255,255,255,.8);border:1px solid var(--input-border);border-radius:8px;color:var(--text);padding:0 12px;backdrop-filter:blur(4px);justify-self:center;height:48px}
+    @media (max-width:600px){#q{max-width:80vw}}
+    @media (prefers-color-scheme: dark){
+      #q{background:rgba(14,17,22,.8)}
+    }
   #mins{flex:1}
   #viewWindow{overflow-x:hidden}
   #viewSlider{display:flex;transition:transform .3s}
@@ -166,24 +184,40 @@
 
 .leaflet-marker-icon.selected{filter:hue-rotate(120deg) brightness(1.3);}
 
-#mapView{display:flex;flex-direction:column;min-width:100%;padding-top:16px;}
-#map{flex:1;border-radius:var(--radius);border:1px solid var(--table-border);}
-#selectedWrap{display:flex;flex-direction:column;flex:1;border:1px solid var(--table-border);border-radius:var(--radius);overflow:hidden;}
-#selectedTop{background:var(--card);border-bottom:1px solid var(--table-border);display:flex;align-items:center;}
+#map{position:fixed;top:0;left:0;right:0;bottom:0;z-index:0;}
+#tablePanel{position:fixed;top:calc(var(--header-h) + 8px);left:0;width:var(--panel-w);height:calc(100% - var(--header-h) - 8px);background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);transform:translateX(-100%);transition:transform .3s;z-index:40;border:1px solid var(--table-border);border-left:none;border-top-right-radius:var(--radius);border-bottom-right-radius:var(--radius);padding-top:0;overflow:hidden;display:flex;flex-direction:column;}
+#tablePanel.open{transform:translateX(0);}
+#closePanel{position:absolute;top:8px;right:24px;background:none;border:none;color:var(--muted);cursor:pointer;font-size:24px;z-index:5}
+#selectedWrap{position:fixed;left:0;right:0;top:var(--header-h);bottom:0;z-index:60;transform:translateY(100%);transition:transform .3s;border-top-left-radius:var(--radius);border-top-right-radius:var(--radius);overflow:hidden;border:1px solid var(--table-border);background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);}
+#selectedWrap.show{transform:translateY(0);}
+#selectedTop{background:transparent;border-bottom:1px solid var(--table-border);display:flex;align-items:center;cursor:grab;}
 #selectedTopScroll{flex:1;overflow-x:auto;-webkit-overflow-scrolling:touch;}
 #selectedTopScroll table{border-collapse:separate;border-spacing:0;display:flex;width:fit-content;}
 #selectedTopScroll tbody{display:flex;}
 #selectedTopScroll tr{display:flex;gap:16px;}
 #selectedTopScroll td{padding:8px 12px;display:flex;align-items:center;gap:4px;white-space:nowrap;flex:0 0 auto;}
 #selectedTopScroll .cell-label{font-weight:600;margin-right:4px;color:var(--muted);}
-#closeSelected{background:none;border:none;color:var(--muted);cursor:pointer;padding:8px 12px;font-size:16px;}
-#selectedDetail{flex:1;overflow:hidden;}
+#closeSelected{background:none;border:none;color:var(--muted);cursor:pointer;padding:8px 12px;font-size:24px;}
+
+#useGeo{font-size:24px;}
+.leaflet-bar a{width:39px;height:39px;line-height:39px;font-size:24px;}
+#selectedDetail{flex:1;overflow:auto;height:calc(100% - 40px);}
 #selectedDetail table,#selectedDetail tbody,#selectedDetail tr,#selectedDetail td.detail{height:100%;}
-#selectedDetail table{width:100%;min-width:0;border-collapse:separate;border-spacing:0;background:var(--card);}
+#selectedDetail table{width:100%;min-width:0;border-collapse:separate;border-spacing:0;background:transparent;}
 #selectedDetail .detail-grid{height:100%;}
 #selectedDetail .detail-grid .info{overflow:auto;}
 @media (max-width:700px){
   #selectedDetail{overflow:auto;}
   #selectedDetail .detail-grid{height:auto;}
   #selectedDetail .detail-grid .info{overflow:visible;}
+}
+
+.leaflet-top{top:var(--header-h)!important;}
+body.panel-open .leaflet-left{left:var(--panel-w);}
+
+@media (max-width:700px){
+  #tablePanel{width:100%;}
+  
+  #selectedWrap{top:var(--header-h);bottom:auto;height:calc(100% - var(--header-h));transform:translateY(100%);transition:transform .3s;}
+  #selectedWrap.show{transform:translateY(0);bottom:auto;}
 }

--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -36,7 +36,7 @@
   header .wrap{max-width:none;margin:0;padding:0}
   main.wrap{padding-top:0}
   h1{margin:0;font-weight:800;font-size:clamp(24px,4vw,40px);white-space:nowrap;line-height:48px;height:48px}
-  .header-row{display:grid;grid-template-columns:auto 1fr auto;align-items:center;column-gap:50px;padding:8px;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px)}
+  .header-row{display:grid;grid-template-columns:auto 1fr auto;align-items:center;column-gap:25px;padding:8px;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px)}
   .settings{justify-self:end;display:flex;align-items:center;gap:8px;position:relative;height:48px}
   .header-row h1{justify-self:start}
   #filterBtn.open{transform:scaleX(-1) rotate(180deg)}
@@ -140,8 +140,8 @@
     }
     #toTop{position:fixed;right:20px;bottom:20px;padding:10px 12px;border-radius:50%;border:none;background:var(--btn-bg);color:var(--text);box-shadow:0 2px 4px rgba(0,0,0,.2);cursor:pointer;display:none;z-index:100;font-size:24px}
   #toTop.show{display:block}
-  #siteFooter{position:fixed;bottom:8px;left:8px;color:#fff;font-size:12px;z-index:80;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);padding:4px 8px;border-radius:var(--radius);border:1px solid var(--table-border)}
-  #siteFooter a{color:#fff}
+  #siteFooter{position:fixed;bottom:8px;left:8px;color:var(--text);font-size:12px;z-index:80;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);padding:4px 8px;border-radius:var(--radius);border:1px solid var(--table-border)}
+  #siteFooter a{color:var(--text)}
   #infoPopup{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);max-width:700px;width:90%;max-height:80vh;overflow:auto;z-index:200;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);border:1px solid var(--table-border);border-radius:var(--radius);padding:16px}
   #infoPopup .info-inner{position:relative}
   #closeInfo{position:absolute;top:8px;right:8px;background:none;border:none;color:var(--muted);cursor:pointer;font-size:24px}
@@ -199,7 +199,8 @@
 #selectedTopScroll .cell-label{font-weight:600;margin-right:4px;color:var(--muted);}
 #closeSelected{background:none;border:none;color:var(--muted);cursor:pointer;padding:8px 12px;font-size:24px;}
 
-.leaflet-bar a{width:39px;height:39px;line-height:39px;font-size:24px;}
+.leaflet-bar a{width:39px;height:39px;line-height:39px;font-size:24px;background:var(--btn-bg);border:1px solid var(--btn-border);color:var(--text);}
+.leaflet-bar a.active{background:var(--btn-alt-bg);border:1px solid var(--accent);}
 #selectedDetail{flex:1;overflow:auto;}
 #selectedDetail table,#selectedDetail tbody,#selectedDetail tr,#selectedDetail td.detail{height:100%;}
 #selectedDetail table{width:100%;min-width:0;border-collapse:separate;border-spacing:0;background:transparent;}
@@ -216,7 +217,5 @@ body.panel-open .leaflet-left{left:var(--panel-w);}
 
 @media (max-width:700px){
   #tablePanel{width:100%;}
-  
-  #selectedWrap{top:var(--header-h);bottom:auto;height:calc(100% - var(--header-h));width:100%;left:0;transform:translateY(100%);transition:transform .3s,width .3s;}
-  #selectedWrap.show{transform:translateY(0);bottom:auto;}
+  #selectedWrap{width:100%;}
 }

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Online eFoil Guide</title>
+<title>eFoil Guide</title>
 <link rel="stylesheet" href="css/style.1.0.0.css">
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
@@ -12,16 +12,16 @@
 <header>
   <div class="wrap">
     <div class="header-row">
-      <h1>Online eFoil Guide</h1>
+      <h1>eFoil Guide</h1>
       <input id="q" placeholder="Search all details" />
       <div class="settings">
-        <a href="#" id="editLocation">Change location</a>
+        <button id="editLocation" aria-label="Change location">📍</button>
         <button id="filterBtn" aria-label="Filters">⚙</button>
         <button id="infoBtn" aria-label="Regulatory quick-reference">ℹ</button>
         <span id="locationBox" class="hidden">
           <div class="loc-row">
             <input id="zip" inputmode="numeric" pattern="[0-9]*" maxlength="5" placeholder="ZIP" />
-            <button id="useGeo" title="Use My Location" aria-label="Use My Location">📍</button>
+            <button id="useGeo" title="Using device location" aria-label="Using device location">Using device location</button>
           </div>
           <div id="originMsg" class="hint">Set your origin to sort by distance &amp; ETA. Your address is never stored.</div>
         </span>
@@ -83,6 +83,7 @@
         <tbody id="spotsBody"></tbody>
       </table>
     </div>
+    <div id="panelGrip"></div>
   </div>
   <div id="selectedWrap" class="hidden bottom-sheet">
     <div id="selectedTop">

--- a/index.html
+++ b/index.html
@@ -11,24 +11,21 @@
 <body>
 <header>
   <div class="wrap">
-    <h1>Online eFoil Guide</h1>
-    <div class="sub">
-      Rig: <strong>Fliteboard Pro + Jet2</strong> • Wings: <strong>MN 1300 C</strong> (front) + <strong>Flow 245 C</strong> (stab) • Battery: <strong>Sport</strong>
-      <br><span id="originInfo" class="hint">
-        <span id="originMsg">Set your origin to sort by distance & ETA. Your address is never stored.</span>
-        <span id="locationBox" class="hidden">
-          <input id="zip" inputmode="numeric" pattern="[0-9]*" maxlength="5" placeholder="ZIP" />
-          <button id="useGeo" title="Use My Location" aria-label="Use My Location">📍</button>
-          <button id="closeLocation" aria-label="Close">✕</button>
-        </span>
-        <a href="#" id="editLocation">Edit location</a>
-      </span>
-    </div>
-
-    <div id="searchRow">
+    <div class="header-row">
+      <h1>Online eFoil Guide</h1>
       <input id="q" placeholder="Search all details" />
-      <button id="viewToggle">Map</button>
-      <button id="filterToggle" aria-expanded="false">Show filters</button>
+      <div class="settings">
+        <a href="#" id="editLocation">Change location</a>
+        <button id="filterBtn" aria-label="Filters">⚙</button>
+        <button id="infoBtn" aria-label="Regulatory quick-reference">ℹ</button>
+        <span id="locationBox" class="hidden">
+          <div class="loc-row">
+            <input id="zip" inputmode="numeric" pattern="[0-9]*" maxlength="5" placeholder="ZIP" />
+            <button id="useGeo" title="Use My Location" aria-label="Use My Location">📍</button>
+          </div>
+          <div id="originMsg" class="hint">Set your origin to sort by distance &amp; ETA. Your address is never stored.</div>
+        </span>
+      </div>
     </div>
     <div id="filters" class="controls hidden">
       <div class="control">
@@ -61,60 +58,67 @@
   </div>
 </header>
 
-<main class="wrap" id="main">
-  <div id="viewWindow">
-    <div id="viewSlider">
-      <div id="tableView">
-        <div class="table-wrap">
-          <table id="tbl">
-            <thead>
-              <tr>
-                <th class="sortable" data-sort="name">Spot</th>
-                <th class="sortable" data-sort="dist" aria-sort="ascending">Dist / Time <span id="sortArrow">⇅</span></th>
-                <th class="sortable" data-sort="water">Water</th>
-                <th class="sortable" data-sort="season">Season</th>
-                <th class="sortable" data-sort="skill">Skill</th>
-              </tr>
-            </thead>
-            <tbody id="spotsBody"></tbody>
-          </table>
-        </div>
-      </div>
-      <div id="mapView">
-        <div id="map"></div>
-        <div id="selectedWrap" class="hidden">
-          <div id="selectedTop">
-            <div id="selectedTopScroll">
-              <table>
-                <tbody id="selectedTopBody"></tbody>
-              </table>
-            </div>
-            <button id="closeSelected" aria-label="Close">✕</button>
-          </div>
-          <div id="selectedDetail"><table><tbody id="selectedBody"></tbody></table></div>
-        </div>
-      </div>
+<main id="main">
+  <div id="map"></div>
+  <div id="tablePanel" class="panel">
+    <button id="closePanel" aria-label="Close">✕</button>
+    <div class="table-wrap">
+      <table id="tbl">
+        <colgroup>
+          <col class="c-name">
+          <col class="c-dist">
+          <col class="c-water">
+          <col class="c-season">
+          <col class="c-skill">
+        </colgroup>
+        <thead>
+          <tr>
+            <th class="sortable" data-sort="name">Spot</th>
+            <th class="sortable" data-sort="dist" aria-sort="ascending">Dist / Time <span id="sortArrow">⇅</span></th>
+            <th class="sortable" data-sort="water">Water</th>
+            <th class="sortable" data-sort="season">Season</th>
+            <th class="sortable" data-sort="skill">Skill</th>
+          </tr>
+        </thead>
+        <tbody id="spotsBody"></tbody>
+      </table>
     </div>
+  </div>
+  <div id="selectedWrap" class="hidden bottom-sheet">
+    <div id="selectedTop">
+      <div id="selectedTopScroll">
+        <table>
+          <tbody id="selectedTopBody"></tbody>
+        </table>
+      </div>
+      <button id="closeSelected" aria-label="Close">✕</button>
+    </div>
+    <div id="selectedDetail"><table><tbody id="selectedBody"></tbody></table></div>
   </div>
   <p class="foot">ETAs use a simple urban/highway model; check your nav app for exact routing.</p>
 </main>
 
+<footer id="siteFooter">© <a href="https://github.com/byterookie" target="_blank">byterookie</a> <span id="year"></span> — This guide summarizes practical rules. Local postings and harbor patrol instructions always take precedence.</footer>
+
 <button id="toTop" aria-label="Back to top">↑</button>
 
-<script src="js/main.1.0.0.js" defer></script>
+<div id="infoPopup" class="hidden">
+  <div class="info-inner">
+    <button id="closeInfo" aria-label="Close">✕</button>
+    <h2>Regulatory quick‑reference</h2>
+    <ul class="muted">
+      <li><strong>Harbors/Marinas:</strong> No‑wake (typically 5 mph) inside fairways until outside breakwaters.</li>
+      <li><strong>CA proximity rule (common‑sense baseline):</strong> 5 mph within ~100 ft of swimmers and ~200 ft of beaches, docks, and moored boats. Always obey posted signs.</li>
+      <li><strong>COLREGS (“Rules of the Road”):</strong> Applies everywhere—give way to vessels constrained by draft (ships/ferries), cross channels at right angles, show lights if dusk/night (avoid night on eFoil).</li>
+      <li><strong>Sanctuaries/Wildlife:</strong> Keep clear of marine mammals; never chase. Heed local eelgrass/sanctuary zones (e.g., parts of Richardson & Tomales bays).</li>
+      <li><strong>Inland lakes:</strong> Expect <em>quagga mussel inspections</em> (arrive clean & dry), day‑use hours, and occasional algae advisories.</li>
+      <li><strong>Night lights:</strong> Pass on the right-hand (white stern) side of other boats; red/green bow lights mean stay clear ahead.</li>
+    </ul>
+    <p class="hint">This guide summarizes practical rules. Local postings and harbor patrol instructions always take precedence.</p>
+  </div>
+</div>
 
-<section class="wrap mb-40">
-  <h2>Regulatory quick‑reference</h2>
-  <ul class="muted">
-    <li><strong>Harbors/Marinas:</strong> No‑wake (typically 5 mph) inside fairways until outside breakwaters.</li>
-    <li><strong>CA proximity rule (common‑sense baseline):</strong> 5 mph within ~100 ft of swimmers and ~200 ft of beaches, docks, and moored boats. Always obey posted signs.</li>
-    <li><strong>COLREGS (“Rules of the Road”):</strong> Applies everywhere—give way to vessels constrained by draft (ships/ferries), cross channels at right angles, show lights if dusk/night (avoid night on eFoil).</li>
-    <li><strong>Sanctuaries/Wildlife:</strong> Keep clear of marine mammals; never chase. Heed local eelgrass/sanctuary zones (e.g., parts of Richardson & Tomales bays).</li>
-    <li><strong>Inland lakes:</strong> Expect <em>quagga mussel inspections</em> (arrive clean & dry), day‑use hours, and occasional algae advisories.</li>
-    <li><strong>Night lights:</strong> Pass on the right-hand (white stern) side of other boats; red/green bow lights mean stay clear ahead.</li>
-  </ul>
-  <p class="hint">This guide summarizes practical rules. Local postings and harbor patrol instructions always take precedence.</p>
-</section>
+<script src="js/main.1.0.0.js" defer></script>
 
 </body>
 </html>

--- a/js/main.1.0.0.js
+++ b/js/main.1.0.0.js
@@ -101,18 +101,77 @@ function detail(label, value, spanClass = '', pClass = '') {
 let ORIGIN = null; // [lat,lng]
 let sortCol = 'dist';
 let originMsg, spotsBody, q, mins, minsVal,
-    waterChips, seasonChips, skillChips,  // chip sets
-    zip, useGeo, filterToggle, filtersEl, headerEl, toTop, sortArrow, tableWrap,
-    viewToggle, viewWindow, viewSlider, mapView, selectedWrap, selectedTopBody, selectedBody, selectedDetail, closeSelected, map,
-    editLocation, locationBox, closeLocation, searchRow;
-let showingMap = false;
+    waterChips, seasonChips, skillChips,
+    zip, useGeo, filtersEl, headerEl, toTop, sortArrow, tableWrap,
+    tablePanel, closePanelBtn, selectedWrap, selectedTop, selectedTopBody, selectedBody, selectedDetail, closeSelected, map,
+    editLocation, locationBox, filterBtn, infoBtn, infoPopup, closeInfo;
 let selectedId = null;
-  let shrinkTable = false;
-  let touchStartY = 0;
 let markers = {};
+let panelOpen = false;
+let hideOthers = false;
+let touchStartY = 0;
 let pageLocked = false;
+let reopenPanel = false;
+let otherCtrlDiv = null;
+let sheetOffset = 0;
+let sheetDragStartY = 0;
+let sheetDragStartOffset = 0;
+let resumeId = null;
 const MAP_START = [37.7749,-122.4194];
 const MAP_ZOOM = 10;
+
+function updateHeaderOffset(){
+  const hTop = headerEl ? headerEl.offsetHeight : 0;
+  document.documentElement.style.setProperty('--header-h', hTop + 'px');
+}
+function handleResize(){
+  updateHeaderOffset();
+  checkShrink();
+}
+
+function openPanel(){
+  if(selectedWrap && selectedWrap.classList.contains('show')){
+    resumeId = selectedId;
+    clearSelected();
+    selectedId = null;
+  }else{
+    resumeId = null;
+  }
+  if(tablePanel){
+    tablePanel.classList.add('open');
+    document.body.classList.add('panel-open');
+    panelOpen = true;
+    document.documentElement.style.setProperty('--panel-w', tablePanel.offsetWidth + 'px');
+    lockPageScroll(true);
+  }
+}
+function closePanel(){
+  if(tablePanel){
+    tablePanel.classList.remove('open');
+    document.body.classList.remove('panel-open');
+    panelOpen = false;
+    lockPageScroll(false);
+    if(resumeId){
+      const id = resumeId;
+      const spot = SPOTS.find(s=>s.id===id);
+      resumeId = null;
+      if(spot){
+        selectedId = id;
+        showSelected(spot);
+      }
+    }
+  }
+}
+function togglePanel(){
+  panelOpen ? closePanel() : openPanel();
+}
+
+function toggleFilters(){
+  if(!filtersEl) return;
+  filtersEl.classList.toggle('hidden');
+  if(filterBtn) filterBtn.classList.toggle('open');
+  handleResize();
+}
 
 function haversine(a,b){
   const toRad = d=>d*Math.PI/180;
@@ -189,7 +248,8 @@ function rowHTML(s){
   <tr class="detail-row hide">
     <td colspan="5" class="detail">
       <div class="detail-grid">
-        <div class="img-box" data-img-id="${s.id}" data-name="${s.name}" data-lat="${s.lat}" data-lng="${s.lng}"></div>
+        <div class="img-box" data-img-id="${s.id}" data-name="${s.name}"></div>
+        <div class="detail-grip"></div>
         <div class="info">
           ${detail('City', s.city)}
           ${detail('Address', s.addr)}
@@ -238,32 +298,14 @@ async function loadImages(){
   for(const box of boxes){
     const id=box.getAttribute('data-img-id');
     const name=box.getAttribute('data-name')||'';
-    const lat=parseFloat(box.getAttribute('data-lat'));
-    const lng=parseFloat(box.getAttribute('data-lng'));
     const srcs=findImages(id);
-
-    box.innerHTML='';
-
     if(srcs.length===0){
-      const mapDiv=document.createElement('div');
-      mapDiv.className='mini-map';
-      box.appendChild(mapDiv);
-      createMiniMap(mapDiv, lat, lng);
-      box.insertAdjacentHTML('beforeend', `<div class="img-credit">Map data &copy; <a href="https://www.openstreetmap.org/" target="_blank">OpenStreetMap contributors</a></div>`);
+      const grip=box.nextElementSibling;
+      if(grip && grip.classList.contains('detail-grip')) grip.remove();
+      box.remove();
       continue;
     }
-
-    const toggle=document.createElement('div');
-    toggle.className='media-toggle';
-    const imgBtn=document.createElement('button');
-    imgBtn.textContent='Images';
-    imgBtn.className='active';
-    const mapBtn=document.createElement('button');
-    mapBtn.textContent='Map';
-    toggle.appendChild(imgBtn);
-    toggle.appendChild(mapBtn);
-    box.appendChild(toggle);
-
+    box.innerHTML='';
     const carousel=document.createElement('div');
     carousel.className='img-carousel';
     srcs.forEach((src,idx)=>{
@@ -304,34 +346,17 @@ async function loadImages(){
       next.addEventListener('click',()=>show(idx+1));
     }
     box.appendChild(carousel);
-
-    const mapHolder=document.createElement('div');
-    mapHolder.className='map-holder';
-    const mapDiv=document.createElement('div');
-    mapDiv.className='mini-map';
-    mapHolder.appendChild(mapDiv);
-    mapHolder.insertAdjacentHTML('beforeend', `<div class="img-credit">Map data &copy; <a href="https://www.openstreetmap.org/" target="_blank">OpenStreetMap contributors</a></div>`);
-    mapHolder.style.display='none';
-    box.appendChild(mapHolder);
-
-    let mapInit=false;
-    imgBtn.addEventListener('click',()=>{
-      imgBtn.classList.add('active');
-      mapBtn.classList.remove('active');
-      carousel.style.display='';
-      mapHolder.style.display='none';
-    });
-    mapBtn.addEventListener('click',()=>{
-      mapBtn.classList.add('active');
-      imgBtn.classList.remove('active');
-      carousel.style.display='none';
-      mapHolder.style.display='';
-      if(!mapInit){ createMiniMap(mapDiv, lat, lng); mapInit=true; }
-    });
   }
 }
 
-function showSelected(s){
+function showSelected(s, fromList=false){
+  resumeId = null;
+  if(panelOpen){
+    closePanel();
+    reopenPanel = true;
+  }else{
+    reopenPanel = false;
+  }
   const temp = document.createElement('tbody');
   temp.innerHTML = rowHTML(s);
   const topRow = temp.querySelector('tr.parent');
@@ -353,21 +378,37 @@ function showSelected(s){
   const info = selectedBody.querySelector('.info');
   if(info) info.scrollTop = 0;
   selectedWrap.classList.remove('hidden');
+  const full = window.innerWidth <= 700;
+  if(full){
+    sheetOffset = 0;
+  }else{
+    sheetOffset = selectedWrap.offsetHeight * 0.4;
+  }
+  selectedWrap.style.transform = `translateY(${sheetOffset}px)`;
+  selectedWrap.classList.add('show');
   loadImages();
-  updateMapHeights();
+  setupDetailDrag();
 }
 
 function clearSelected(){
   if(selectedId && markers[selectedId]) setMarkerSelected(markers[selectedId], false);
   selectedTopBody.innerHTML='';
   selectedBody.innerHTML='';
+  selectedWrap.classList.remove('show');
   selectedWrap.classList.add('hidden');
+  selectedWrap.style.transform='';
+  sheetOffset = 0;
   document.querySelectorAll('#tbl tbody tr.parent.open').forEach(o=>{
     o.classList.remove('open');
     const d=o.nextElementSibling;
     if(d && d.classList.contains('detail-row')) d.classList.add('hide');
   });
-  updateMapHeights();
+  if(reopenPanel){
+    openPanel();
+    reopenPanel = false;
+  }
+  updateOtherMarkers();
+  hideOthers = false;
 }
 
 function setMarkerSelected(marker, sel){
@@ -375,14 +416,34 @@ function setMarkerSelected(marker, sel){
   if(el) el.classList.toggle('selected', sel);
 }
 
-function updateMapHeights(){
-  if(!showingMap) return;
-  const top = viewWindow.getBoundingClientRect().top;
-  const avail = window.innerHeight - top;
-  mapView.style.height = avail + 'px';
-  viewWindow.style.height = avail + 'px';
-  if(map) map.invalidateSize();
+function flyToSpot(latlng){
+  if(!map) return;
+  map.flyTo(latlng,16);
+  map.once('moveend',()=>{
+    if(selectedWrap && selectedWrap.classList.contains('show')){
+      const visible = selectedWrap.offsetHeight - sheetOffset;
+      const offset = Math.max(0, visible/2 - 80);
+      map.panBy([0, offset]);
+    }
+  });
 }
+
+function updateOtherMarkers(){
+  if(otherCtrlDiv) otherCtrlDiv.classList.toggle('hidden', !selectedId);
+  if(!selectedId) hideOthers = false;
+  Object.entries(markers).forEach(([id, marker])=>{
+    if(id === selectedId){
+      if(!map.hasLayer(marker)) marker.addTo(map);
+    }else{
+      if(hideOthers && selectedId){
+        if(map.hasLayer(marker)) map.removeLayer(marker);
+      }else{
+        if(!map.hasLayer(marker)) marker.addTo(map);
+      }
+    }
+  });
+}
+
 
 function moveSortArrow(th){
   if(sortArrow) th.appendChild(sortArrow);
@@ -392,25 +453,8 @@ function moveSortArrow(th){
 
 function updateTableScroll(){
   if(!tableWrap || !spotsBody) return;
-  const rows = [...spotsBody.querySelectorAll('tr.parent:not(.hide)')];
-  if(rows.length===0){
-    tableWrap.classList.remove('scroll');
-    spotsBody.style.maxHeight='';
-    return;
-  }
-  const h = rows[0].getBoundingClientRect().height;
-  const top = tableWrap.getBoundingClientRect().top;
-  const avail = window.innerHeight - top;
-  const maxVisible = Math.floor(avail / h);
-  const target = shrinkTable ? 5 : 10;
-  const maxRows = Math.min(target, maxVisible);
-  if(rows.length>maxRows){
-    tableWrap.classList.add('scroll');
-    spotsBody.style.maxHeight = h*maxRows + 'px';
-  }else{
-    tableWrap.classList.remove('scroll');
-    spotsBody.style.maxHeight='';
-  }
+  tableWrap.classList.remove('scroll');
+  spotsBody.style.maxHeight='';
 }
 
 function tableInView(){
@@ -421,7 +465,7 @@ function tableInView(){
 }
 
 function consumeTableScroll(dy){
-  if(showingMap || !tableWrap || !tableWrap.classList.contains('scroll')) return false;
+  if(!tableWrap || !tableWrap.classList.contains('scroll')) return false;
   if(!tableInView()) return false;
   const atTop = spotsBody.scrollTop === 0;
   const atBottom = spotsBody.scrollTop + spotsBody.clientHeight >= spotsBody.scrollHeight;
@@ -435,7 +479,7 @@ function consumeTableScroll(dy){
 }
 
 function consumeDetailScroll(dy){
-  if(!showingMap || !selectedDetail || selectedDetail.scrollHeight <= selectedDetail.clientHeight) return false;
+  if(!selectedDetail || selectedDetail.scrollHeight <= selectedDetail.clientHeight) return false;
   const atTop = selectedDetail.scrollTop === 0;
   const atBottom = selectedDetail.scrollTop + selectedDetail.clientHeight >= selectedDetail.scrollHeight;
   if((dy < 0 && !atTop) || (dy > 0 && !atBottom)){
@@ -473,16 +517,62 @@ function handleTouchMove(e){
   }
 }
 
-function checkShrink(){
-  const shouldShrink = window.scrollY>0 || window.innerHeight<700;
-  if(shouldShrink !== shrinkTable){
-    shrinkTable = shouldShrink;
-    if(shrinkTable && spotsBody){
-      spotsBody.scrollTop = 0;
-      lockPageScroll(true);
-    }
-    updateTableScroll();
+function startSheetDrag(e){
+  if(!selectedWrap || !selectedWrap.classList.contains('show')) return;
+  sheetDragStartY = e.touches ? e.touches[0].clientY : e.clientY;
+  sheetDragStartOffset = sheetOffset;
+  selectedWrap.style.transition = 'none';
+  document.addEventListener('touchmove', sheetDragMove, {passive:false});
+  document.addEventListener('touchend', endSheetDrag);
+  document.addEventListener('mousemove', sheetDragMove);
+  document.addEventListener('mouseup', endSheetDrag);
+}
+
+function sheetDragMove(e){
+  const y = e.touches ? e.touches[0].clientY : e.clientY;
+  let dy = y - sheetDragStartY;
+  let newOffset = sheetDragStartOffset + dy;
+  const max = selectedWrap.offsetHeight - 80;
+  if(newOffset < 0) newOffset = 0;
+  if(newOffset > max) newOffset = max;
+  sheetOffset = newOffset;
+  selectedWrap.style.transform = `translateY(${sheetOffset}px)`;
+  e.preventDefault();
+}
+
+function endSheetDrag(){
+  selectedWrap.style.transition = '';
+  document.removeEventListener('touchmove', sheetDragMove);
+  document.removeEventListener('touchend', endSheetDrag);
+  document.removeEventListener('mousemove', sheetDragMove);
+  document.removeEventListener('mouseup', endSheetDrag);
+}
+
+function setupDetailDrag(){
+  const grip = selectedBody ? selectedBody.querySelector('.detail-grip') : null;
+  const img = selectedBody ? selectedBody.querySelector('.img-box') : null;
+  if(!grip || !img) return;
+  let startX = 0;
+  let startW = 0;
+  grip.addEventListener('mousedown', e=>{
+    startX = e.clientX;
+    startW = img.offsetWidth;
+    document.addEventListener('mousemove', move);
+    document.addEventListener('mouseup', up);
+    e.preventDefault();
+  });
+  function move(e){
+    const w = startW + (e.clientX - startX);
+    if(w>100) img.style.flex = `0 0 ${w}px`;
   }
+  function up(){
+    document.removeEventListener('mousemove', move);
+    document.removeEventListener('mouseup', up);
+  }
+}
+
+function checkShrink(){
+  // table always uses full panel height; no shrink handling needed
 }
 
 function render(){
@@ -513,70 +603,20 @@ function render(){
 function attachRowHandlers(){
   document.querySelectorAll('#tbl tbody tr.parent').forEach(tr=>{
     tr.addEventListener('click',()=>{
-      const wasOpen = tr.classList.contains('open');
       const id = tr.getAttribute('data-id');
-      document.querySelectorAll('#tbl tbody tr.parent.open').forEach(o=>{
-        if(o!==tr){
-          o.classList.remove('open');
-          const d=o.nextElementSibling;
-          if(d && d.classList.contains('detail-row')) d.classList.add('hide');
-        }
-      });
-      tr.classList.toggle('open', !wasOpen);
-      const detail = tr.nextElementSibling;
-      if(detail && detail.classList.contains('detail-row')){
-        detail.classList.toggle('hide', wasOpen);
-      }
-      if(!wasOpen){
-        if(selectedId && selectedId!==id && markers[selectedId]) setMarkerSelected(markers[selectedId], false);
-        selectedId = id;
-        if(showingMap && markers[id]){
-          setMarkerSelected(markers[id], true);
-          const spot = SPOTS.find(s=>s.id===id);
-          if(spot) showSelected(spot);
-        }
-      }else if(selectedId===id){
-        if(markers[id]) setMarkerSelected(markers[id], false);
-        selectedId = null;
-        if(showingMap) clearSelected();
+      if(selectedId && selectedId!==id && markers[selectedId]) setMarkerSelected(markers[selectedId], false);
+      selectedId = id;
+      if(markers[id]){
+        setMarkerSelected(markers[id], true);
+        flyToSpot(markers[id].getLatLng());
+        const spot = SPOTS.find(s=>s.id===id);
+        if(spot) showSelected(spot, true);
+        updateOtherMarkers();
       }
     });
   });
 }
 
-function openTableRow(id, block='start'){
-  const tr = document.querySelector(`#tbl tbody tr.parent[data-id="${id}"]`);
-  if(!tr) return;
-  const wasOpen = tr.classList.contains('open');
-  document.querySelectorAll('#tbl tbody tr.parent.open').forEach(o=>{
-    if(o!==tr){
-      o.classList.remove('open');
-      const d=o.nextElementSibling;
-      if(d && d.classList.contains('detail-row')) d.classList.add('hide');
-    }
-  });
-  tr.classList.add('open');
-  const detail = tr.nextElementSibling;
-  if(detail && detail.classList.contains('detail-row')) detail.classList.remove('hide');
-  if(!wasOpen) {
-    if(selectedId && selectedId!==id && markers[selectedId]) setMarkerSelected(markers[selectedId], false);
-    selectedId = id;
-  }
-  if(spotsBody && tableWrap && tableWrap.classList.contains('scroll')){
-    const trRect = tr.getBoundingClientRect();
-    const bodyRect = spotsBody.getBoundingClientRect();
-    const offset = trRect.top - bodyRect.top + spotsBody.scrollTop;
-    if(block==='center'){
-      spotsBody.scrollTop = offset - spotsBody.clientHeight/2 + trRect.height/2;
-    }else{
-      const max = spotsBody.scrollHeight - spotsBody.clientHeight;
-      spotsBody.scrollTop = Math.min(offset, max);
-    }
-  }else{
-    tr.scrollIntoView({block});
-  }
-  loadImages();
-}
 
 function applyTileScheme(m){
   const light = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -608,16 +648,18 @@ function initMap(){
     const marker = L.marker([s.lat, s.lng]).addTo(map);
     markers[s.id] = marker;
     marker.on('click', () => {
-      map.flyTo([s.lat, s.lng], 16);
+      flyToSpot([s.lat, s.lng]);
       if(selectedId === s.id){
         setMarkerSelected(marker,false);
         selectedId = null;
         clearSelected();
+        updateOtherMarkers();
       }else{
         if(selectedId && markers[selectedId]) setMarkerSelected(markers[selectedId], false);
         selectedId = s.id;
         setMarkerSelected(marker,true);
         showSelected(s);
+        updateOtherMarkers();
       }
     });
   });
@@ -625,6 +667,7 @@ function initMap(){
     if(selectedId && markers[selectedId]) setMarkerSelected(markers[selectedId], false);
     selectedId = null;
     clearSelected();
+    updateOtherMarkers();
   });
 
   const reset = L.control({position:'topleft'});
@@ -636,20 +679,41 @@ function initMap(){
     a.title = 'Reset view';
     L.DomEvent.on(a,'click',e=>{
       L.DomEvent.preventDefault(e);
+      L.DomEvent.stopPropagation(e);
       map.setView(MAP_START, MAP_ZOOM);
     });
     return div;
   };
   reset.addTo(map);
 
-  applyFilters();
-}
+  const listCtrl = L.control({position:'topleft'});
+  listCtrl.onAdd = function(){
+    const div = L.DomUtil.create('div','leaflet-bar');
+    const a = L.DomUtil.create('a','',div);
+    a.href='#';
+    a.innerHTML='≡';
+    a.title='Show list';
+    L.DomEvent.on(a,'click',e=>{L.DomEvent.preventDefault(e);L.DomEvent.stopPropagation(e);togglePanel();});
+    return div;
+  };
+  listCtrl.addTo(map);
 
-function createMiniMap(el, lat, lng){
-  const m = L.map(el, { attributionControl:false }).setView([lat, lng], 17);
-  applyTileScheme(m);
-  L.marker([lat, lng]).addTo(m);
-  window.setTimeout(()=>m.invalidateSize(),0);
+  const otherCtrl = L.control({position:'topright'});
+  otherCtrl.onAdd = function(){
+    const div = L.DomUtil.create('div','leaflet-bar hidden');
+    const a = L.DomUtil.create('a','',div);
+    a.href='#';
+    a.innerHTML='👁';
+    a.title='Show other spots';
+    L.DomEvent.on(a,'click',e=>{L.DomEvent.preventDefault(e);L.DomEvent.stopPropagation(e);hideOthers=!hideOthers;updateOtherMarkers();});
+    otherCtrlDiv = div;
+    return div;
+  };
+  otherCtrl.addTo(map);
+
+  applyFilters();
+  updateOtherMarkers();
+  updateHeaderOffset();
 }
 
 /* ---------- Filters ---------- */
@@ -732,40 +796,62 @@ function setOrigin(lat,lng,label){
     originMsg = document.getElementById('originMsg');
     editLocation = document.getElementById('editLocation');
     locationBox = document.getElementById('locationBox');
-    closeLocation = document.getElementById('closeLocation');
     spotsBody = document.getElementById('spotsBody');
     q = document.getElementById('q');
     mins = document.getElementById('mins');
     minsVal = document.getElementById('minsVal');
-    searchRow = document.getElementById('searchRow');
     waterChips = [...document.querySelectorAll('.f-water')];
     seasonChips = [...document.querySelectorAll('.f-season')];
     skillChips = [...document.querySelectorAll('.f-skill')];
     zip = document.getElementById('zip');
     useGeo = document.getElementById('useGeo');
-    filterToggle = document.getElementById('filterToggle');
     filtersEl = document.getElementById('filters');
-    // ensure toggle text matches initial state
-    const filtersHidden = filtersEl.classList.contains('hidden');
-    filterToggle.textContent = filtersHidden ? 'Show filters' : 'Hide filters';
-    filterToggle.setAttribute('aria-expanded', filtersHidden ? 'false' : 'true');
     headerEl = document.querySelector('header');
     toTop = document.getElementById('toTop');
-    viewToggle = document.getElementById('viewToggle');
-    viewWindow = document.getElementById('viewWindow');
-    viewSlider = document.getElementById('viewSlider');
-    mapView = document.getElementById('mapView');
+    tablePanel = document.getElementById('tablePanel');
+    closePanelBtn = document.getElementById('closePanel');
     selectedWrap = document.getElementById('selectedWrap');
+    selectedTop = document.getElementById('selectedTop');
     selectedTopBody = document.getElementById('selectedTopBody');
     selectedBody = document.getElementById('selectedBody');
     selectedDetail = document.getElementById('selectedDetail');
     closeSelected = document.getElementById('closeSelected');
     tableWrap = document.querySelector('.table-wrap');
+    filterBtn = document.getElementById('filterBtn');
+    infoBtn = document.getElementById('infoBtn');
+    infoPopup = document.getElementById('infoPopup');
+    closeInfo = document.getElementById('closeInfo');
+    const yearEl = document.getElementById('year');
+    if(yearEl) yearEl.textContent = new Date().getFullYear();
 
     if(closeSelected){
       closeSelected.addEventListener('click', ()=>{
         clearSelected();
         selectedId = null;
+      });
+    }
+    if(closePanelBtn){
+      closePanelBtn.addEventListener('click', ()=>closePanel());
+    }
+
+    if(selectedTop){
+      selectedTop.addEventListener('mousedown', startSheetDrag);
+      selectedTop.addEventListener('touchstart', startSheetDrag, {passive:false});
+    }
+    if(filterBtn){
+      filterBtn.addEventListener('click', e=>{e.preventDefault();toggleFilters();});
+    }
+    if(infoBtn && infoPopup){
+      infoBtn.addEventListener('click', e => {
+        e.preventDefault();
+        const hidden = infoPopup.classList.toggle('hidden');
+        lockPageScroll(!hidden);
+      });
+    }
+    if(closeInfo && infoPopup){
+      closeInfo.addEventListener('click', () => {
+        infoPopup.classList.add('hidden');
+        lockPageScroll(false);
       });
     }
 
@@ -789,63 +875,17 @@ function setOrigin(lat,lng,label){
 
     sortArrow = document.getElementById('sortArrow');
 
-    viewToggle.addEventListener('click', () => {
-      showingMap = !showingMap;
-      viewSlider.style.transform = showingMap ? 'translateX(-100%)' : 'translateX(0)';
-      viewToggle.textContent = showingMap ? 'Table' : 'Map';
-      window.scrollTo(0,0);
-      if(spotsBody) spotsBody.scrollTop = 0;
-      if(mapView) mapView.scrollTop = 0;
-      lockPageScroll(false);
-      checkShrink();
-      if(showingMap){
-        // size the container before Leaflet initializes to avoid a zero-height map
-        updateMapHeights();
-        initMap();
-        applyFilters();
-        updateMapView();
-        // run again once visible so Leaflet recalculates dimensions
-        window.requestAnimationFrame(updateMapHeights);
-        if(selectedId){
-          const spot = SPOTS.find(s=>s.id===selectedId);
-          if(spot){
-            if(markers[selectedId]) setMarkerSelected(markers[selectedId], true);
-            showSelected(spot);
-            map.flyTo([spot.lat, spot.lng], 16);
-          }
-        }else{
-          clearSelected();
-        }
-      }else{
-        viewWindow.style.height = '';
-        mapView.style.height = '';
-        clearSelected();
-        if(selectedId) window.requestAnimationFrame(()=>openTableRow(selectedId,'start'));
-      }
-    });
-
-      // toggle filters visibility and button label
-      filterToggle.addEventListener('click', () => {
-        const willOpen = filtersEl.classList.contains('hidden');
-        filtersEl.classList.toggle('hidden');
-        filterToggle.textContent = willOpen ? 'Hide filters' : 'Show filters';
-        filterToggle.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
-        handleResize();
-      });
-
     editLocation.addEventListener('click', e => {
       e.preventDefault();
-      editLocation.classList.add('hidden');
-      locationBox.classList.remove('hidden');
-      searchRow.style.marginTop = '8px';
-      zip.focus();
-      handleResize();
-    });
-
-    closeLocation.addEventListener('click', () => {
-      locationBox.classList.add('hidden');
-      editLocation.classList.remove('hidden');
-      searchRow.style.marginTop = '';
+      const open = !locationBox.classList.contains('hidden');
+      if(open){
+        locationBox.classList.add('hidden');
+        editLocation.textContent = 'Change location';
+      }else{
+        locationBox.classList.remove('hidden');
+        editLocation.textContent = 'Close location';
+        zip.focus();
+      }
       handleResize();
     });
 
@@ -853,14 +893,6 @@ function setOrigin(lat,lng,label){
 
 
 
-  function updateHeaderOffset(){
-    document.documentElement.style.setProperty('--header-h', headerEl.offsetHeight + 'px');
-  }
-  function handleResize(){
-    updateHeaderOffset();
-    updateMapHeights();
-    checkShrink();
-  }
   window.addEventListener('resize', handleResize);
   handleResize();
 
@@ -926,6 +958,8 @@ zip.addEventListener('input', async () => {
   SPOTS = await loadSpots();
   await loadImageCredits();
   render();
+  initMap();
+  applyFilters();
 
   window.addEventListener('scroll', () => {
     toTop.classList.toggle('show', window.scrollY > 200);


### PR DESCRIPTION
## Summary
- overlay footer with dynamic copyright notice and disclaimer
- center search between title and settings, match their heights, and widen info popup for readability
- drop table drag handles, widen the spot column, and allow detail text to scroll
- keep table headers fixed, restore translucent header row with reordered controls, and toggle info popup on repeat clicks

## Testing
- `node --check js/main.1.0.0.js`
- `npx eslint .` *(fails: Parsing error: 'import' and 'export' may appear only with 'sourceType: module')*


------
https://chatgpt.com/codex/tasks/task_e_68a142a8ddb08330bd9107eda3491ea9