### PR TITLE
Fix map zoom when selecting search suggestion

### DIFF
--- a/js/main.1.0.0.js
+++ b/js/main.1.0.0.js
@@ -787,7 +787,7 @@ function applyFilters(){
     }
   });
   minsVal.textContent = `≤ ${mins.value} min`;
-  updateMapView();
+  if(!selectedId) updateMapView();
 }
 
 function hideSuggestions(){


### PR DESCRIPTION
## Summary
- Avoid resetting map view after choosing a search suggestion so the map flies to the selected spot

## Testing
- `npx eslint js/main.1.0.0.js`


------
https://chatgpt.com/codex/tasks/task_e_68a18183d7d88330b2354fb6c65d12f2