### PR TITLE
feat: redesign bottom sheet with top image

### DIFF
--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -201,13 +201,13 @@
 #tablePanel.open{transform:translateX(0);}
 #panelGrip{position:absolute;top:0;right:0;width:8px;height:100%;cursor:col-resize}
 #closePanel{position:absolute;top:8px;right:24px;background:none;border:none;color:var(--muted);cursor:pointer;font-size:24px;z-index:5}
-#selectedWrap{position:fixed;left:50%;top:0;bottom:0;width:75%;max-width:800px;z-index:60;transform:translate(-50%,100%);transition:transform .3s,width .3s;border-top-left-radius:var(--radius);border-top-right-radius:var(--radius);overflow:hidden;border:1px solid var(--table-border);background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);display:flex;flex-direction:column;}
+#selectedWrap{position:fixed;left:50%;top:0;bottom:0;width:65%;max-width:800px;z-index:60;transform:translate(-50%,100%);transition:transform .3s,width .3s;border-top-left-radius:var(--radius);border-top-right-radius:var(--radius);overflow:hidden;border:1px solid var(--table-border);background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);display:flex;flex-direction:column;}
 #selectedWrap.show{transform:translate(-50%,0);}
-#selectedTop{position:relative;cursor:grab;}
+#selectedTop{position:relative;cursor:grab;overflow:hidden;}
 #selectedTop.scrolled{border-bottom:1px solid var(--table-border);}
 #selectedTop .img-box{width:100%;transition:opacity .3s,height .3s;}
 #selectedTop.scrolled .img-box{opacity:0;height:0;}
-#selectedOverlay{position:absolute;left:0;bottom:0;width:100%;background:linear-gradient(to top,rgba(0,0,0,.6),rgba(0,0,0,0));color:#fff;padding:8px 0;transition:background .3s,color .3s;}
+#selectedOverlay{position:absolute;left:0;bottom:0;width:100%;background:linear-gradient(to top,rgba(0,0,0,.8),rgba(0,0,0,0));color:#fff;padding:8px 0;transition:background .3s,color .3s;}
 #selectedTop.scrolled #selectedOverlay{position:relative;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));color:var(--text);}
 #selectedTopScroll{overflow-x:auto;-webkit-overflow-scrolling:touch;}
 #selectedTopScroll table{border-collapse:separate;border-spacing:0;display:flex;width:fit-content;}

--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -130,20 +130,22 @@
     td.detail p{margin:6px 0}
   .detail-grid{display:flex;align-items:flex-start}
   .detail-grid .detail-grip{flex:0 0 8px;cursor:col-resize}
-  .detail-grid .img-box{flex:0 0 300px;max-width:100%;position:sticky;top:0;overflow:hidden}
-    .detail-grid .img-box img{width:100%;height:auto;border-radius:8px;display:block}
-    .detail-grid .img-box .img-credit{font-size:12px;color:var(--muted);margin-top:4px}
-    .detail-grid .img-box .slide{display:none}
-    .detail-grid .img-box .slide.active{display:block}
-    .detail-grid .img-box .img-carousel{position:relative}
-    .detail-grid .img-box .img-carousel button{position:absolute;top:50%;transform:translateY(-50%);background:rgba(0,0,0,.5);color:#fff;border:none;padding:4px 8px;border-radius:4px;cursor:pointer}
-    .detail-grid .img-box .img-carousel button.prev{left:4px}
-    .detail-grid .img-box .img-carousel button.next{right:4px}
-    .detail-grid .info{flex:2 1 260px}
-    @media (max-width:700px){
-      .detail-grid{flex-direction:column}
-      .detail-grid .img-box{max-width:100%;position:static}
-    }
+  .img-box{position:relative;overflow:hidden}
+    .img-box img{width:100%;height:auto;display:block}
+    .img-box .img-credit{font-size:12px;color:var(--muted);margin-top:4px}
+    .img-box .slide{position:absolute;top:0;left:0;width:100%;opacity:0;transition:opacity .3s}
+    .img-box .slide.active{position:relative;opacity:1}
+    .img-box .img-carousel{position:relative}
+    .img-box .img-carousel button{position:absolute;top:50%;transform:translateY(-50%);background:rgba(0,0,0,.5);color:#fff;border:none;padding:4px 8px;border-radius:4px;cursor:pointer}
+    .img-box .img-carousel button.prev{left:4px}
+    .img-box .img-carousel button.next{right:4px}
+  .detail-grid .img-box{flex:0 0 300px;max-width:100%;position:sticky;top:0}
+    .detail-grid .img-box img{border-radius:8px}
+  .detail-grid .info{flex:2 1 260px}
+  @media (max-width:700px){
+    .detail-grid{flex-direction:column}
+    .detail-grid .img-box{max-width:100%;position:static}
+  }
   #siteFooter{position:fixed;bottom:8px;left:8px;color:var(--text);font-size:12px;z-index:80;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);padding:4px 8px;border-radius:var(--radius);border:1px solid var(--table-border)}
   #siteFooter a{color:var(--text)}
   #infoPopup{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);max-width:700px;width:90%;max-height:80vh;overflow:auto;z-index:200;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);border:1px solid var(--table-border);border-radius:var(--radius);padding:16px}
@@ -201,14 +203,20 @@
 #closePanel{position:absolute;top:8px;right:24px;background:none;border:none;color:var(--muted);cursor:pointer;font-size:24px;z-index:5}
 #selectedWrap{position:fixed;left:50%;top:0;bottom:0;width:75%;max-width:800px;z-index:60;transform:translate(-50%,100%);transition:transform .3s,width .3s;border-top-left-radius:var(--radius);border-top-right-radius:var(--radius);overflow:hidden;border:1px solid var(--table-border);background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);display:flex;flex-direction:column;}
 #selectedWrap.show{transform:translate(-50%,0);}
-#selectedTop{background:transparent;border-bottom:1px solid var(--table-border);display:flex;align-items:center;cursor:grab;}
-#selectedTopScroll{flex:1;overflow-x:auto;-webkit-overflow-scrolling:touch;}
+#selectedTop{position:relative;cursor:grab;}
+#selectedTop.scrolled{border-bottom:1px solid var(--table-border);}
+#selectedTop .img-box{width:100%;transition:opacity .3s,height .3s;}
+#selectedTop.scrolled .img-box{opacity:0;height:0;}
+#selectedOverlay{position:absolute;left:0;bottom:0;width:100%;background:linear-gradient(to top,rgba(0,0,0,.6),rgba(0,0,0,0));color:#fff;padding:8px 0;transition:background .3s,color .3s;}
+#selectedTop.scrolled #selectedOverlay{position:relative;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));color:var(--text);}
+#selectedTopScroll{overflow-x:auto;-webkit-overflow-scrolling:touch;}
 #selectedTopScroll table{border-collapse:separate;border-spacing:0;display:flex;width:fit-content;}
 #selectedTopScroll tbody{display:flex;}
   #selectedTopScroll tr{display:flex;gap:8px;}
-  #selectedTopScroll td{padding:4px 8px;display:flex;align-items:center;gap:4px;white-space:nowrap;flex:0 0 auto;}
+  #selectedTopScroll td{padding:4px 8px;display:flex;align-items:center;gap:4px;white-space:nowrap;flex:0 0 auto;color:inherit;}
 #selectedTopScroll .cell-label{font-weight:600;margin-right:4px;color:var(--muted);}
-#closeSelected{background:none;border:none;color:var(--muted);cursor:pointer;padding:8px 12px;font-size:24px;}
+#closeSelected{position:absolute;top:8px;right:8px;background:none;border:none;color:var(--muted);cursor:pointer;padding:8px 12px;font-size:24px;}
+#scrollTopBtn{position:absolute;top:8px;right:48px;background:none;border:none;color:var(--muted);cursor:pointer;font-size:20px;}
 
   .leaflet-bar a{width:39px;height:39px;line-height:39px;font-size:24px;background:var(--btn-bg);border:1px solid var(--btn-border);color:var(--text);}
   .leaflet-bar a.active{background:var(--btn-alt-bg);border:1px solid var(--accent);}

--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -205,7 +205,7 @@
 #selectedWrap.show{transform:translate(-50%,0);}
 #selectedTop{position:relative;cursor:grab;overflow:hidden;}
 #selectedTop.scrolled{border-bottom:1px solid var(--table-border);}
-#selectedTop .img-box{width:100%;transition:opacity .3s,height .3s;}
+#selectedTop .img-box{width:100%;overflow:hidden;}
 #selectedTop.scrolled .img-box{opacity:0;height:0;}
 #selectedOverlay{position:absolute;left:0;bottom:0;width:100%;background:linear-gradient(to top,rgba(0,0,0,.8),rgba(0,0,0,0));color:#fff;padding:8px 0;transition:background .3s,color .3s;}
 #selectedTop.scrolled #selectedOverlay{position:relative;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));color:var(--text);}

--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -216,7 +216,7 @@
   #selectedTopScroll td{padding:4px 8px;display:flex;align-items:center;gap:4px;white-space:nowrap;flex:0 0 auto;color:inherit;}
 #selectedTopScroll .cell-label{font-weight:600;margin-right:4px;color:var(--muted);}
 #closeSelected{position:absolute;top:8px;right:8px;background:none;border:none;color:var(--muted);cursor:pointer;padding:8px 12px;font-size:24px;}
-#scrollTopBtn{position:absolute;top:8px;right:48px;background:none;border:none;color:var(--muted);cursor:pointer;font-size:20px;}
+#scrollTopBtn{position:absolute;bottom:16px;right:16px;background:none;border:none;color:var(--muted);cursor:pointer;font-size:20px;z-index:70;}
 
   .leaflet-bar a{width:39px;height:39px;line-height:39px;font-size:24px;background:var(--btn-bg);border:1px solid var(--btn-border);color:var(--text);}
   .leaflet-bar a.active{background:var(--btn-alt-bg);border:1px solid var(--accent);}

--- a/index.html
+++ b/index.html
@@ -98,10 +98,10 @@
           </table>
         </div>
       </div>
-      <button id="scrollTopBtn" class="hidden" aria-label="Back to top">⇧</button>
       <button id="closeSelected" aria-label="Close">✕</button>
     </div>
     <div id="selectedDetail"><table><tbody id="selectedBody"></tbody></table></div>
+    <button id="scrollTopBtn" class="hidden" aria-label="Back to top">⇧</button>
   </div>
   <p class="foot">ETAs use a simple urban/highway model; check your nav app for exact routing.</p>
 </main>

--- a/index.html
+++ b/index.html
@@ -91,11 +91,14 @@
   </div>
   <div id="selectedWrap" class="hidden bottom-sheet" role="dialog" aria-modal="true" aria-hidden="true">
     <div id="selectedTop">
-      <div id="selectedTopScroll">
-        <table>
-          <tbody id="selectedTopBody"></tbody>
-        </table>
+      <div id="selectedOverlay">
+        <div id="selectedTopScroll">
+          <table>
+            <tbody id="selectedTopBody"></tbody>
+          </table>
+        </div>
       </div>
+      <button id="scrollTopBtn" class="hidden" aria-label="Back to top">⇧</button>
       <button id="closeSelected" aria-label="Close">✕</button>
     </div>
     <div id="selectedDetail"><table><tbody id="selectedBody"></tbody></table></div>

--- a/js/main.1.0.0.js
+++ b/js/main.1.0.0.js
@@ -957,6 +957,9 @@ function setOrigin(lat,lng,label){
     if(selectedTop){
       selectedTop.addEventListener('mousedown', startSheetDrag);
       selectedTop.addEventListener('touchstart', startSheetDrag, {passive:false});
+      selectedTop.addEventListener('transitionend', e=>{
+        if(e.target.classList.contains('img-box')) updateSheetHeight();
+      });
     }
     if(selectedDetail){
       selectedDetail.addEventListener('scroll', ()=>{
@@ -967,7 +970,7 @@ function setOrigin(lat,lng,label){
         if(scrollTopBtn){
           scrollTopBtn.classList.toggle('hidden', st <= 20);
         }
-        updateSheetHeight();
+        window.requestAnimationFrame(updateSheetHeight);
       });
     }
     if(filterBtn){

--- a/js/main.1.0.0.js
+++ b/js/main.1.0.0.js
@@ -103,8 +103,9 @@ let sortCol = 'dist';
 let originMsg, spotsBody, q, qSuggest, qClear, mins, minsVal,
     waterChips, seasonChips, skillChips,
     zip, useGeo, filtersEl, headerEl, sortArrow,
-    tablePanel, closePanelBtn, selectedWrap, selectedTop, selectedTopBody, selectedBody, selectedDetail, closeSelected, map,
+    tablePanel, closePanelBtn, selectedWrap, selectedTop, selectedTopBody, selectedBody, selectedDetail, closeSelected, scrollTopBtn, map,
     editLocation, locationBox, filterBtn, infoBtn, infoPopup, closeInfo, panelGrip, siteTitle;
+let selectedImgBox = null;
 let selectedId = null;
 let markers = {};
 let panelOpen = false;
@@ -405,10 +406,25 @@ function showSelected(s, fromList=false){
     });
   }
   if(detail) detail.classList.remove('hide');
+  if(detail){
+    selectedImgBox = detail.querySelector('.img-box');
+    const grip = detail.querySelector('.detail-grip');
+    if(selectedImgBox){
+      selectedTop.insertBefore(selectedImgBox, selectedTop.firstChild);
+      if(grip) grip.remove();
+    }
+  } else {
+    selectedImgBox = null;
+  }
   selectedTopBody.innerHTML = '';
   if(topRow) selectedTopBody.appendChild(topRow);
   selectedBody.innerHTML = '';
   if(detail) selectedBody.appendChild(detail);
+  if(selectedTop){
+    if(selectedImgBox) selectedTop.classList.remove('scrolled');
+    else selectedTop.classList.add('scrolled');
+  }
+  if(scrollTopBtn) scrollTopBtn.classList.add('hidden');
   selectedDetail.scrollTop = 0;
   const info = selectedBody.querySelector('.info');
   if(info) info.scrollTop = 0;
@@ -427,6 +443,10 @@ function clearSelected(){
   if(selectedId && markers[selectedId]) setMarkerSelected(markers[selectedId], false);
   selectedTopBody.innerHTML='';
   selectedBody.innerHTML='';
+  if(selectedImgBox){
+    selectedImgBox.remove();
+    selectedImgBox = null;
+  }
   selectedWrap.classList.remove('show');
   selectedWrap.classList.add('hidden');
   selectedWrap.setAttribute('aria-hidden','true');
@@ -434,6 +454,8 @@ function clearSelected(){
   selectedWrap.style.height='';
   if(selectedDetail) selectedDetail.style.maxHeight='';
   sheetOffset = 0;
+  if(selectedTop) selectedTop.classList.remove('scrolled');
+  if(scrollTopBtn) scrollTopBtn.classList.add('hidden');
   document.querySelectorAll('#tbl tbody tr.parent.open').forEach(o=>{
     o.classList.remove('open');
     const d=o.nextElementSibling;
@@ -873,6 +895,7 @@ function setOrigin(lat,lng,label){
     selectedBody = document.getElementById('selectedBody');
     selectedDetail = document.getElementById('selectedDetail');
     closeSelected = document.getElementById('closeSelected');
+    scrollTopBtn = document.getElementById('scrollTopBtn');
     filterBtn = document.getElementById('filterBtn');
     infoBtn = document.getElementById('infoBtn');
     infoPopup = document.getElementById('infoPopup');
@@ -885,6 +908,11 @@ function setOrigin(lat,lng,label){
       closeSelected.addEventListener('click', ()=>{
         clearSelected();
         selectedId = null;
+      });
+    }
+    if(scrollTopBtn && selectedDetail){
+      scrollTopBtn.addEventListener('click', ()=>{
+        selectedDetail.scrollTo({top:0, behavior:'smooth'});
       });
     }
     if(closePanelBtn){
@@ -929,6 +957,18 @@ function setOrigin(lat,lng,label){
     if(selectedTop){
       selectedTop.addEventListener('mousedown', startSheetDrag);
       selectedTop.addEventListener('touchstart', startSheetDrag, {passive:false});
+    }
+    if(selectedDetail){
+      selectedDetail.addEventListener('scroll', ()=>{
+        const st = selectedDetail.scrollTop;
+        if(selectedTop){
+          selectedTop.classList.toggle('scrolled', st > 20 || !selectedTop.querySelector('.img-box'));
+        }
+        if(scrollTopBtn){
+          scrollTopBtn.classList.toggle('hidden', st <= 20);
+        }
+        updateSheetHeight();
+      });
     }
     if(filterBtn){
       filterBtn.addEventListener('click', e=>{e.preventDefault();toggleFilters();});

--- a/js/main.1.0.0.js
+++ b/js/main.1.0.0.js
@@ -604,8 +604,9 @@ function updateSheetHeight(){
 function handleDetailScroll(){
   const outer = selectedDetail ? selectedDetail.scrollTop : 0;
   const inner = sheetInfo ? sheetInfo.scrollTop : 0;
+  const st = Math.max(outer, inner);
   if(selectedImgBox && selectedImgHeight > 0){
-    const collapse = Math.min(outer, selectedImgHeight);
+    const collapse = Math.min(st, selectedImgHeight);
     const remain = selectedImgHeight - collapse;
     selectedImgBox.style.height = remain + 'px';
     selectedImgBox.style.opacity = remain / selectedImgHeight;
@@ -616,7 +617,6 @@ function handleDetailScroll(){
     if(selectedDetail) selectedDetail.style.transform = '';
   }
   if(scrollTopBtn){
-    const st = Math.max(outer, inner);
     scrollTopBtn.classList.toggle('hidden', st <= 20);
   }
   window.requestAnimationFrame(updateSheetHeight);

--- a/js/main.1.0.0.js
+++ b/js/main.1.0.0.js
@@ -103,7 +103,7 @@ let sortCol = 'dist';
 let originMsg, spotsBody, q, qSuggest, qClear, mins, minsVal,
     waterChips, seasonChips, skillChips,
     zip, useGeo, filtersEl, headerEl, sortArrow,
-    tablePanel, closePanelBtn, selectedWrap, selectedTop, selectedTopBody, selectedBody, selectedDetail, closeSelected, scrollTopBtn, map,
+    tablePanel, closePanelBtn, selectedWrap, selectedTop, selectedTopBody, selectedBody, selectedDetail, closeSelected, scrollTopBtn, map, sheetInfo,
     editLocation, locationBox, filterBtn, infoBtn, infoPopup, closeInfo, panelGrip, siteTitle;
 let selectedImgBox = null;
 let selectedId = null;
@@ -426,8 +426,16 @@ function showSelected(s, fromList=false){
   }
   if(scrollTopBtn) scrollTopBtn.classList.add('hidden');
   selectedDetail.scrollTop = 0;
+  if(sheetInfo){
+    sheetInfo.removeEventListener('scroll', handleDetailScroll);
+    sheetInfo = null;
+  }
   const info = selectedBody.querySelector('.info');
-  if(info) info.scrollTop = 0;
+  if(info){
+    info.scrollTop = 0;
+    info.addEventListener('scroll', handleDetailScroll);
+    sheetInfo = info;
+  }
   selectedWrap.classList.remove('hidden');
   selectedWrap.setAttribute('aria-hidden','false');
   sheetOffset = window.innerWidth >= 768 ? window.innerHeight / 2 : 0;
@@ -443,6 +451,10 @@ function clearSelected(){
   if(selectedId && markers[selectedId]) setMarkerSelected(markers[selectedId], false);
   selectedTopBody.innerHTML='';
   selectedBody.innerHTML='';
+  if(sheetInfo){
+    sheetInfo.removeEventListener('scroll', handleDetailScroll);
+    sheetInfo = null;
+  }
   if(selectedImgBox){
     selectedImgBox.remove();
     selectedImgBox = null;
@@ -569,6 +581,17 @@ function updateSheetHeight(){
     const topH = selectedTop.offsetHeight;
     selectedDetail.style.maxHeight = (h - topH) + 'px';
   }
+}
+
+function handleDetailScroll(){
+  const st = Math.max(selectedDetail ? selectedDetail.scrollTop : 0, sheetInfo ? sheetInfo.scrollTop : 0);
+  if(selectedTop){
+    selectedTop.classList.toggle('scrolled', st > 20 || !selectedImgBox);
+  }
+  if(scrollTopBtn){
+    scrollTopBtn.classList.toggle('hidden', st <= 20);
+  }
+  window.requestAnimationFrame(updateSheetHeight);
 }
 
 function setupDetailDrag(){
@@ -913,6 +936,7 @@ function setOrigin(lat,lng,label){
     if(scrollTopBtn && selectedDetail){
       scrollTopBtn.addEventListener('click', ()=>{
         selectedDetail.scrollTo({top:0, behavior:'smooth'});
+        if(sheetInfo) sheetInfo.scrollTo({top:0, behavior:'smooth'});
       });
     }
     if(closePanelBtn){
@@ -962,16 +986,7 @@ function setOrigin(lat,lng,label){
       });
     }
     if(selectedDetail){
-      selectedDetail.addEventListener('scroll', ()=>{
-        const st = selectedDetail.scrollTop;
-        if(selectedTop){
-          selectedTop.classList.toggle('scrolled', st > 20 || !selectedTop.querySelector('.img-box'));
-        }
-        if(scrollTopBtn){
-          scrollTopBtn.classList.toggle('hidden', st <= 20);
-        }
-        window.requestAnimationFrame(updateSheetHeight);
-      });
+      selectedDetail.addEventListener('scroll', handleDetailScroll);
     }
     if(filterBtn){
       filterBtn.addEventListener('click', e=>{e.preventDefault();toggleFilters();});


### PR DESCRIPTION
## Summary
- move spot image carousel to top of bottom sheet with gradient overlay
- fade image out on scroll and show back-to-top button
- add crossfade animation between carousel images

## Testing
- `npx eslint js/main.1.0.0.js`
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a1813285b4833092dcaf34a05d9e73