### PR TITLE
Improve mobile search usability

### DIFF
--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -167,7 +167,7 @@
     #useGeo{font-size:12px;color:var(--accent);cursor:pointer;}
     #q{width:100%;max-width:50vw;min-width:0;background:rgba(255,255,255,.8);border:1px solid var(--input-border);border-radius:8px;color:var(--text);padding:0 32px 0 12px;backdrop-filter:blur(4px);justify-self:center;height:48px}
     #qClear{position:absolute;right:8px;top:50%;transform:translateY(-50%);background:none;border:none;color:var(--text);font-size:20px;cursor:pointer;padding:0;line-height:1}
-    #searchToggle{display:none;align-items:center;justify-content:center;background:var(--btn-bg);border:1px solid var(--btn-border);color:var(--text);border-radius:8px;width:48px;height:48px;font-size:20px;cursor:pointer}
+    #searchToggle{display:none}
     @media (max-width:600px){
       #q{max-width:80vw}
       .search-wrap{width:min(80vw,100%)}
@@ -175,21 +175,24 @@
     @media (prefers-color-scheme: dark){
       #q{background:rgba(14,17,22,.8)}
     }
-    @media (max-width:400px){
-      #q{display:none}
-      #qClear{display:none}
-      #searchToggle{display:flex}
-    }
     .search-wrap.full{position:fixed;top:8px;left:8px;right:8px;z-index:90}
     .search-wrap.full #q{display:block;width:100%}
     .search-wrap.full #qClear{display:block}
-    .search-wrap.full #searchToggle{display:none}
+
+    .search-collapsed #q{display:none}
+    .search-collapsed #qClear{display:none}
+    .search-collapsed #searchToggle{display:flex}
+
+    header.searching .header-row > *:not(.search-wrap){
+      filter:blur(4px);
+      opacity:0;
+      pointer-events:none;
+    }
 @media (max-width:600px){
   h1{line-height:40px;height:40px;font-size:clamp(20px,5vw,28px)}
   .settings{height:40px}
   .settings button{width:40px;height:40px;font-size:20px}
   #q{height:40px}
-  #searchToggle{width:40px;height:40px}
 }
   #mins{flex:1}
 

--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -167,6 +167,7 @@
     #useGeo{font-size:12px;color:var(--accent);cursor:pointer;}
     #q{width:100%;max-width:50vw;min-width:0;background:rgba(255,255,255,.8);border:1px solid var(--input-border);border-radius:8px;color:var(--text);padding:0 32px 0 12px;backdrop-filter:blur(4px);justify-self:center;height:48px}
     #qClear{position:absolute;right:8px;top:50%;transform:translateY(-50%);background:none;border:none;color:var(--text);font-size:20px;cursor:pointer;padding:0;line-height:1}
+    #searchToggle{display:none;align-items:center;justify-content:center;background:var(--btn-bg);border:1px solid var(--btn-border);color:var(--text);border-radius:8px;width:48px;height:48px;font-size:20px;cursor:pointer}
     @media (max-width:600px){
       #q{max-width:80vw}
       .search-wrap{width:min(80vw,100%)}
@@ -174,11 +175,21 @@
     @media (prefers-color-scheme: dark){
       #q{background:rgba(14,17,22,.8)}
     }
+    @media (max-width:400px){
+      #q{display:none}
+      #qClear{display:none}
+      #searchToggle{display:flex}
+    }
+    .search-wrap.full{position:fixed;top:8px;left:8px;right:8px;z-index:90}
+    .search-wrap.full #q{display:block;width:100%}
+    .search-wrap.full #qClear{display:block}
+    .search-wrap.full #searchToggle{display:none}
 @media (max-width:600px){
   h1{line-height:40px;height:40px;font-size:clamp(20px,5vw,28px)}
   .settings{height:40px}
   .settings button{width:40px;height:40px;font-size:20px}
   #q{height:40px}
+  #searchToggle{width:40px;height:40px}
 }
   #mins{flex:1}
 

--- a/index.html
+++ b/index.html
@@ -14,12 +14,12 @@
     <div class="header-row">
       <h1>eFoil Guide</h1>
       <div class="search-wrap">
-        <button id="searchToggle" aria-label="Search">🔍</button>
         <input id="q" placeholder="Search all details" aria-label="Search spots" />
         <button id="qClear" class="hidden" aria-label="Clear search">✕</button>
         <ul id="qSuggest" class="hidden" role="listbox"></ul>
       </div>
       <div class="settings">
+        <button id="searchToggle" aria-label="Search">🔍</button>
         <button id="editLocation" aria-label="Change location">📍</button>
         <button id="filterBtn" aria-label="Filters">⚙</button>
         <button id="infoBtn" aria-label="Regulatory quick-reference">ℹ</button>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <div class="header-row">
       <h1>eFoil Guide</h1>
       <div class="search-wrap">
+        <button id="searchToggle" aria-label="Search">🔍</button>
         <input id="q" placeholder="Search all details" aria-label="Search spots" />
         <button id="qClear" class="hidden" aria-label="Clear search">✕</button>
         <ul id="qSuggest" class="hidden" role="listbox"></ul>

--- a/js/main.1.0.0.js
+++ b/js/main.1.0.0.js
@@ -121,7 +121,7 @@ let resumeId = null;
 let suggestIndex = -1;
 const MAP_START = [37.7749,-122.4194];
 const MAP_ZOOM = 10;
-const MOBILE_BP = 400; // px width to collapse search
+const SEARCH_COLLAPSE_W = 75; // px width to collapse search
 
 function updateHeaderOffset(){
   const hTop = headerEl ? headerEl.offsetHeight : 0;
@@ -133,9 +133,6 @@ function handleResize(){
   if(selectedWrap && selectedWrap.classList.contains('show')){
     updateSheetTransform();
     updateSheetHeight();
-  }
-  if(searchWrap && window.innerWidth > MOBILE_BP){
-    searchWrap.classList.remove('full');
   }
 }
 
@@ -587,7 +584,14 @@ function setupDetailDrag(){
 }
 
 function checkShrink(){
-  // table always uses full panel height; no shrink handling needed
+  if(!searchWrap) return;
+  if(searchWrap.classList.contains('full')) return;
+  if(searchWrap.offsetWidth < SEARCH_COLLAPSE_W){
+    document.body.classList.add('search-collapsed');
+  }else{
+    document.body.classList.remove('search-collapsed');
+    if(headerEl) headerEl.classList.remove('searching');
+  }
 }
 
 function render(){
@@ -939,6 +943,7 @@ function setOrigin(lat,lng,label){
     if(searchToggle && searchWrap && q){
       searchToggle.addEventListener('click', () => {
         searchWrap.classList.add('full');
+        if(headerEl) headerEl.classList.add('searching');
         q.focus();
       });
     }
@@ -1065,9 +1070,11 @@ function setOrigin(lat,lng,label){
             showSelected(spot, true);
             updateOtherMarkers();
             applyFilters();
-            if(window.innerWidth <= MOBILE_BP && searchWrap){
+            if(document.body.classList.contains('search-collapsed') && searchWrap){
               searchWrap.classList.remove('full');
+              if(headerEl) headerEl.classList.remove('searching');
               q.blur();
+              checkShrink();
             }
           }
           e.preventDefault();
@@ -1083,8 +1090,10 @@ function setOrigin(lat,lng,label){
         qClear.classList.add('hidden');
         hideSuggestions();
         applyFilters();
-        if(window.innerWidth <= MOBILE_BP && searchWrap){
+        if(document.body.classList.contains('search-collapsed') && searchWrap){
           searchWrap.classList.remove('full');
+          if(headerEl) headerEl.classList.remove('searching');
+          checkShrink();
         }else{
           q.focus();
         }
@@ -1106,9 +1115,11 @@ function setOrigin(lat,lng,label){
         showSelected(spot, true);
         updateOtherMarkers();
         applyFilters();
-        if(window.innerWidth <= MOBILE_BP && searchWrap){
+        if(document.body.classList.contains('search-collapsed') && searchWrap){
           searchWrap.classList.remove('full');
+          if(headerEl) headerEl.classList.remove('searching');
           q.blur();
+          checkShrink();
         }
       };
       qSuggest.addEventListener('mousedown', choose);
@@ -1116,8 +1127,10 @@ function setOrigin(lat,lng,label){
       q.addEventListener('blur', () => {
         window.setTimeout(() => {
           hideSuggestions();
-          if(window.innerWidth <= MOBILE_BP && searchWrap && q.value.trim()===''){
+          if(document.body.classList.contains('search-collapsed') && searchWrap && q.value.trim()===''){
             searchWrap.classList.remove('full');
+            if(headerEl) headerEl.classList.remove('searching');
+            checkShrink();
           }
         },100);
       });

--- a/js/main.1.0.0.js
+++ b/js/main.1.0.0.js
@@ -100,7 +100,7 @@ function detail(label, value, spanClass = '', pClass = '') {
 /* ---------- Distance & ETA ---------- */
 let ORIGIN = null; // [lat,lng]
 let sortCol = 'dist';
-let originMsg, spotsBody, q, qSuggest, qClear, mins, minsVal,
+let originMsg, spotsBody, q, qSuggest, qClear, searchWrap, searchToggle, mins, minsVal,
     waterChips, seasonChips, skillChips,
     zip, useGeo, filtersEl, headerEl, sortArrow,
     tablePanel, closePanelBtn, selectedWrap, selectedTop, selectedTopBody, selectedBody, selectedDetail, closeSelected, map,
@@ -121,6 +121,7 @@ let resumeId = null;
 let suggestIndex = -1;
 const MAP_START = [37.7749,-122.4194];
 const MAP_ZOOM = 10;
+const MOBILE_BP = 400; // px width to collapse search
 
 function updateHeaderOffset(){
   const hTop = headerEl ? headerEl.offsetHeight : 0;
@@ -132,6 +133,9 @@ function handleResize(){
   if(selectedWrap && selectedWrap.classList.contains('show')){
     updateSheetTransform();
     updateSheetHeight();
+  }
+  if(searchWrap && window.innerWidth > MOBILE_BP){
+    searchWrap.classList.remove('full');
   }
 }
 
@@ -856,6 +860,8 @@ function setOrigin(lat,lng,label){
     q = document.getElementById('q');
     qSuggest = document.getElementById('qSuggest');
     qClear = document.getElementById('qClear');
+    searchWrap = document.querySelector('.search-wrap');
+    searchToggle = document.getElementById('searchToggle');
     mins = document.getElementById('mins');
     minsVal = document.getElementById('minsVal');
     waterChips = [...document.querySelectorAll('.f-water')];
@@ -929,6 +935,12 @@ function setOrigin(lat,lng,label){
     if(selectedTop){
       selectedTop.addEventListener('mousedown', startSheetDrag);
       selectedTop.addEventListener('touchstart', startSheetDrag, {passive:false});
+    }
+    if(searchToggle && searchWrap && q){
+      searchToggle.addEventListener('click', () => {
+        searchWrap.classList.add('full');
+        q.focus();
+      });
     }
     if(filterBtn){
       filterBtn.addEventListener('click', e=>{e.preventDefault();toggleFilters();});
@@ -1053,6 +1065,10 @@ function setOrigin(lat,lng,label){
             showSelected(spot, true);
             updateOtherMarkers();
             applyFilters();
+            if(window.innerWidth <= MOBILE_BP && searchWrap){
+              searchWrap.classList.remove('full');
+              q.blur();
+            }
           }
           e.preventDefault();
         }
@@ -1067,7 +1083,11 @@ function setOrigin(lat,lng,label){
         qClear.classList.add('hidden');
         hideSuggestions();
         applyFilters();
-        q.focus();
+        if(window.innerWidth <= MOBILE_BP && searchWrap){
+          searchWrap.classList.remove('full');
+        }else{
+          q.focus();
+        }
       });
     }
     if(qSuggest){
@@ -1086,10 +1106,21 @@ function setOrigin(lat,lng,label){
         showSelected(spot, true);
         updateOtherMarkers();
         applyFilters();
+        if(window.innerWidth <= MOBILE_BP && searchWrap){
+          searchWrap.classList.remove('full');
+          q.blur();
+        }
       };
       qSuggest.addEventListener('mousedown', choose);
       qSuggest.addEventListener('touchstart', choose, {passive:false});
-      q.addEventListener('blur',()=>window.setTimeout(hideSuggestions,100));
+      q.addEventListener('blur', () => {
+        window.setTimeout(() => {
+          hideSuggestions();
+          if(window.innerWidth <= MOBILE_BP && searchWrap && q.value.trim()===''){
+            searchWrap.classList.remove('full');
+          }
+        },100);
+      });
     }
     mins.addEventListener('input', () => {
       applyFilters();


### PR DESCRIPTION
## Summary
- Replace cramped search input with a search icon on very small screens
- Expand icon into full-width search field when tapped
- Close the expanded search when clearing, leaving the field, or selecting a suggestion

## Testing
- `npm test` *(fails: no package.json)*
- `npx eslint js/main.1.0.0.js`


------
https://chatgpt.com/codex/tasks/task_e_68a1821e09048330973aef2adeba983e