### PR TITLE
feat: redesign detail sections

### DIFF
--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -120,14 +120,13 @@
   .foot{color:var(--muted);font-size:12px;margin-top:8px}
   section{scroll-margin-top:var(--header-h)}
   .card{background:var(--card);border:1px solid var(--control-border);border-radius:var(--radius);padding:16px;margin:16px 0}
-  .law{font-size:13px;color:var(--accent)}
+  .detail-item.law .detail-value{font-size:13px;color:var(--accent)}
   .amen{color:var(--accent)}
   .mono{font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, monospace}
   .muted{color:var(--muted)}
     .pill{display:inline-block;background:var(--control-border);border:1px solid var(--badge-border);color:var(--text);padding:2px 8px;border-radius:999px;margin-right:6px;font-size:12px}
     .hint{font-size:12px;color:var(--muted)}
     td.detail{padding:16px;font-size:14px}
-    td.detail p{margin:6px 0}
   .detail-grid{display:flex;align-items:flex-start}
   .detail-grid .detail-grip{flex:0 0 8px;cursor:col-resize}
   .detail-grid .img-box{flex:0 0 300px;max-width:100%;position:sticky;top:0;overflow:hidden}
@@ -140,6 +139,13 @@
     .detail-grid .img-box .img-carousel button.prev{left:4px}
     .detail-grid .img-box .img-carousel button.next{right:4px}
     .detail-grid .info{flex:2 1 260px}
+    .detail-section{margin-bottom:16px}
+    .detail-section h4{margin:0 0 8px;font-size:15px}
+    .detail-section-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:8px}
+    .detail-item{background:var(--card);border:1px solid var(--control-border);border-radius:var(--radius);padding:8px 12px}
+    .detail-item.span-2{grid-column:span 2}
+    .detail-label{font-size:12px;font-weight:600;color:var(--muted)}
+    .detail-value{font-size:14px;margin-top:4px}
     @media (max-width:700px){
       .detail-grid{flex-direction:column}
       .detail-grid .img-box{max-width:100%;position:static}

--- a/js/main.1.0.0.js
+++ b/js/main.1.0.0.js
@@ -90,11 +90,17 @@ function parseCitations(str=''){
     });
 }
 
-function detail(label, value, spanClass = '', pClass = '') {
+function detail(label, value, spanClass = '', wrapClass = '') {
   if (value == null || String(value).trim() === '') return '';
   const text = parseCitations(String(value));
   const span = spanClass ? `<span class="${spanClass}">${text}</span>` : text;
-  return `<p class="${pClass}"><strong>${label}:</strong> ${span}</p>`;
+  return `<div class="detail-item ${wrapClass}"><div class="detail-label">${label}</div><div class="detail-value">${span}</div></div>`;
+}
+
+function detailSection(title, items) {
+  const content = items.filter(Boolean).join('');
+  if (!content) return '';
+  return `<div class="detail-section"><h4>${title}</h4><div class="detail-section-grid">${content}</div></div>`;
 }
 
 /* ---------- Distance & ETA ---------- */
@@ -263,6 +269,54 @@ function rowHTML(s){
   const distMi = ORIGIN ? haversine(ORIGIN,[s.lat,s.lng]) : null;
   const eta = distMi!=null ? etaMinutes(distMi) : null;
   const distTxt = distMi!=null ? `${Math.round(distMi)} mi / ~${eta} min` : '—';
+  const locationDetails = [
+    detail('City', `<a href="https://maps.google.com/?q=${encodeURIComponent(s.city)}" target="_blank">${s.city}</a>`),
+    detail('Address', `<a href="https://maps.google.com/?q=${encodeURIComponent(s.addr)}" target="_blank">${s.addr}</a>`),
+    detail('Coordinates', `<a href="https://www.google.com/maps?q=${s.lat},${s.lng}" target="_blank" class="mono">${s.lat.toFixed(4)}, ${s.lng.toFixed(4)}</a>`)
+  ];
+  const launchDetails = [
+    detail('Launch', s.launch),
+    detail('Parking', s.parking),
+    detail('Amenities', s.amenities, 'amen')
+  ];
+  const safetyDetails = [
+    detail('Pros', s.pros, 'ok'),
+    detail('Cons', s.cons, 'warn'),
+    detail('Crowd Level', s.pop),
+    detail('Best For', s.best),
+    detail('Hazards & Tips', s.tips, '', 'span-2'),
+    detail('Avoid', s.avoid, '', 'span-2'),
+    detail('Best Conditions', s.best_conditions, '', 'span-2')
+  ];
+  const lawsDetails = [
+    detail('Laws / Regs', s.law, '', 'law span-2')
+  ];
+  const routesDetails = [
+    s.routes_beginner ? detail('Routes (Beginner)', s.routes_beginner, '', 'span-2') : '',
+    s.routes_pro ? detail('Routes (Pro)', s.routes_pro, '', 'span-2') : ''
+  ];
+  const gearDetails = [
+    detail('Gear Fit', s.gear, '', 'span-2'),
+    s.setup_fit ? detail('Setup Fit', s.setup_fit, '', 'span-2') : ''
+  ];
+  const miscDetails = [
+    s.parking_cost ? detail('Parking Cost', s.parking_cost) : '',
+    s.parking_distance_m ? detail('Parking Distance (m)', s.parking_distance_m) : '',
+    s.bathrooms ? detail('Bathrooms', s.bathrooms) : '',
+    s.showers ? detail('Showers', s.showers) : '',
+    s.rinse ? detail('Rinse', s.rinse) : '',
+    s.fees ? detail('Fees', s.fees) : '',
+    s.popularity ? detail('Popularity', s.popularity) : ''
+  ];
+  const sections = [
+    detailSection('Location', locationDetails),
+    detailSection('Launch, Parking & Amenities', launchDetails),
+    detailSection('Safety & Conditions', safetyDetails),
+    detailSection('Laws & Regulations', lawsDetails),
+    detailSection('Routes', routesDetails),
+    detailSection('Setup & Gear', gearDetails),
+    detailSection('Other', miscDetails)
+  ].join('');
   return `<tr class="parent" data-id="${s.id}" data-mi="${distMi||9999}" data-eta="${eta||9999}">
     <td class="spot" data-label="Spot">${s.name}</td>
     <td data-label="Dist / Time">${distTxt}</td>
@@ -275,33 +329,7 @@ function rowHTML(s){
       <div class="detail-grid">
         <div class="img-box" data-img-id="${s.id}" data-name="${s.name}"></div>
         <div class="detail-grip"></div>
-        <div class="info">
-          ${detail('City', s.city)}
-          ${detail('Address', s.addr)}
-          ${detail('Coordinates', `<a href="https://www.google.com/maps?q=${s.lat},${s.lng}" target="_blank" class="mono">${s.lat.toFixed(4)}, ${s.lng.toFixed(4)}</a>`)}
-          ${detail('Launch', s.launch)}
-          ${detail('Parking', s.parking)}
-          ${detail('Amenities', s.amenities, 'amen')}
-          ${detail('Pros', s.pros, 'ok')}
-          ${detail('Cons', s.cons, 'warn')}
-          ${detail('Crowd Level', s.pop)}
-          ${detail('Best For', s.best)}
-          ${detail('Gear Fit', s.gear)}
-          ${detail('Hazards & Tips', s.tips)}
-          ${detail('Laws / Regs', s.law, '', 'law')}
-          ${s.parking_cost ? detail('Parking Cost', s.parking_cost) : ''}
-          ${s.parking_distance_m ? detail('Parking Distance (m)', s.parking_distance_m) : ''}
-          ${s.bathrooms ? detail('Bathrooms', s.bathrooms) : ''}
-          ${s.showers ? detail('Showers', s.showers) : ''}
-          ${s.rinse ? detail('Rinse', s.rinse) : ''}
-          ${s.fees ? detail('Fees', s.fees) : ''}
-          ${s.routes_beginner ? detail('Routes (Beginner)', s.routes_beginner) : ''}
-          ${s.routes_pro ? detail('Routes (Pro)', s.routes_pro) : ''}
-          ${s.avoid ? detail('Avoid', s.avoid) : ''}
-          ${s.best_conditions ? detail('Best Conditions', s.best_conditions) : ''}
-          ${s.setup_fit ? detail('Setup Fit', s.setup_fit) : ''}
-          ${s.popularity ? detail('Popularity', s.popularity) : ''}
-        </div>
+        <div class="info">${sections}</div>
       </div>
     </td>
   </tr>`;


### PR DESCRIPTION
## Summary
- redesign detail layout into modern two-column sections
- add Google Maps links for city, address, and coordinates
- style new section cards to match site look

## Testing
- `node --check js/main.1.0.0.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a187c7f1cc8330bbc4d52177aaf960