### PR TITLE
Replace custom CSV parser with PapaParse

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,6 +123,7 @@
   </div>
 </div>
 
+<script src="https://unpkg.com/papaparse@5.4.1/papaparse.min.js" defer></script>
 <script src="js/main.1.0.0.js" defer></script>
 
 </body>

--- a/js/main.1.0.0.js
+++ b/js/main.1.0.0.js
@@ -26,42 +26,17 @@ const ZIP_CENTROIDS = {
 let SPOTS = [];// loaded from CSV
 let IMG_CREDITS = {};// loaded from JSON mapping filenames to credit info
 
-function parseCSV(text){
-  const lines = text.trim().split(/\r?\n/);
-  const headers = lines[0].split(',');
-  return lines.slice(1).filter(l=>l.trim()).map(line=>{
-    const values=[];
-    let cur='', inQuotes=false;
-    for(let i=0;i<line.length;i++){
-      const ch=line[i];
-      if(inQuotes){
-        if(ch=='"'){
-          if(line[i+1]=='"'){cur+='"'; i++;}
-          else inQuotes=false;
-        }else{cur+=ch;}
-      }else{
-        if(ch=='"'){inQuotes=true;}
-        else if(ch==','){values.push(cur); cur='';}
-        else{cur+=ch;}
-      }
-    }
-    values.push(cur);
-    const obj={};
-    headers.forEach((h,i)=>{
-      const v=(values[i]||'').trim();
-      obj[h]=v;
-    });
-    obj.lat=parseFloat(obj.lat);
-    obj.lng=parseFloat(obj.lng);
-    obj.skill=obj.skill?obj.skill.split('|'):[];
-    return obj;
-  });
-}
-
 async function loadSpots(){
   const resp = await fetch('data/locations.csv');
   const text = await resp.text();
-  return parseCSV(text);
+  const parsed = Papa.parse(text, { header: true, skipEmptyLines: true });
+  return parsed.data.map(row => {
+    const obj = { ...row };
+    obj.lat = parseFloat(obj.lat);
+    obj.lng = parseFloat(obj.lng);
+    obj.skill = obj.skill ? obj.skill.split('|') : [];
+    return obj;
+  });
 }
 
 


### PR DESCRIPTION
## Summary
- Include PapaParse via CDN in `index.html`
- Replace bespoke `parseCSV` with `Papa.parse` and update `loadSpots`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a18e766e1c83309315abb4f06e74d2