### PR TITLE
feat: keep selected spot centered with sheet

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,8 @@ export default [
         navigator: "readonly",
         localStorage: "readonly",
         fetch: "readonly",
-        L: "readonly"
+        L: "readonly",
+        Papa: "readonly"
       }
     },
     rules: {


### PR DESCRIPTION
## Summary
- auto-center selected map spot between header and bottom sheet
- stop auto-centering when user drags or zooms the map
- declare Papa global for ESLint

## Testing
- `npx eslint js/main.1.0.0.js`

------
https://chatgpt.com/codex/tasks/task_e_68a1913eb83483309426bad23322ab0e