### PR TITLE
Render sanitized HTML in detail sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,6 +130,7 @@
   </div>
 </div>
 
+  <script src="https://unpkg.com/dompurify@3.0.6/dist/purify.min.js" defer></script>
   <script src="js/parseCitations.js" defer></script>
   <script src="js/main.1.0.0.js" defer></script>
 

--- a/js/main.1.0.0.js
+++ b/js/main.1.0.0.js
@@ -119,8 +119,7 @@ function detail(label, value, spanClass = '', wrapClass = '', icon = '') {
   if (typeof window !== 'undefined' && value instanceof window.Node) {
     target.appendChild(value);
   } else {
-    const nodes = parseCitations(String(value));
-    target.appendChild(nodes);
+    target.innerHTML = parseCitations(String(value));
   }
   if (target !== valueDiv) valueDiv.appendChild(target);
   wrap.appendChild(labelDiv);

--- a/js/parseCitations.js
+++ b/js/parseCitations.js
@@ -1,3 +1,11 @@
+let DOMPurify;
+if (typeof window !== 'undefined' && window.DOMPurify) {
+  DOMPurify = window.DOMPurify;
+} else {
+  const { JSDOM } = require('jsdom');
+  DOMPurify = require('dompurify')(new JSDOM('').window);
+}
+
 function parseCitations(str = '') {
   const tokens = [];
   let i = 0;
@@ -109,25 +117,18 @@ function parseCitations(str = '') {
     }
   }
 
-  const container = document.createDocumentFragment();
+  let out = '';
   tokens.forEach(tok => {
     if (tok.type === 'text') {
-      container.appendChild(document.createTextNode(tok.value));
+      out += tok.value;
     } else {
-      container.appendChild(document.createTextNode(tok.text));
+      out += tok.text;
       tok.sources.forEach(src => {
-        const span = document.createElement('span');
-        span.className = 'cite-group';
-        const a = document.createElement('a');
-        a.href = src.url;
-        a.target = '_blank';
-        a.textContent = src.name;
-        span.appendChild(a);
-        container.appendChild(span);
+        out += `<span class="cite-group"><a href="${src.url}" target="_blank">${src.name}</a></span>`;
       });
     }
   });
-  return container;
+  return DOMPurify ? DOMPurify.sanitize(out) : out;
 }
 
 if (typeof window !== 'undefined') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "efoilguide",
       "version": "1.0.0",
       "devDependencies": {
+        "dompurify": "^3.0.6",
         "jsdom": "^24.0.0"
       }
     },
@@ -140,6 +141,14 @@
         "node": ">=18"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -252,6 +261,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "node --test"
   },
   "devDependencies": {
-    "jsdom": "^24.0.0"
+    "jsdom": "^24.0.0",
+    "dompurify": "^3.0.6"
   }
 }
 

--- a/test/parseCitations.test.js
+++ b/test/parseCitations.test.js
@@ -12,8 +12,8 @@ function setupDom() {
 
 test('parses citation into link groups', () => {
   const dom = setupDom();
-  const node = parseCitations('Intro {{Citation: "text" SourceName: "One", "Two" SourceURL: "u1", "u2"}} end');
-  dom.window.document.body.appendChild(node);
+  const html = parseCitations('Intro {{Citation: "text" SourceName: "One", "Two" SourceURL: "u1", "u2"}} end');
+  dom.window.document.body.innerHTML = html;
   const groups = dom.window.document.querySelectorAll('.cite-group');
   assert.equal(groups.length, 2);
   assert.equal(groups[0].querySelector('a').textContent, 'One');
@@ -23,27 +23,26 @@ test('parses citation into link groups', () => {
 test('malformed citation remains unchanged', () => {
   const dom = setupDom();
   const input = 'Bad {{Citation: "oops" SourceName: "Only"}} end';
-  const node = parseCitations(input);
-  dom.window.document.body.appendChild(node);
+  const html = parseCitations(input);
+  dom.window.document.body.innerHTML = html;
   assert.equal(dom.window.document.body.textContent, input);
 });
 
 test('nested citation treated as text', () => {
   const dom = setupDom();
   const input = 'Nested {{Citation: "text {{Citation: \"inner\" SourceName: \"N\" SourceURL: \"U\" }} more" SourceName: "Outer" SourceURL: "Out"}} tail';
-  const node = parseCitations(input);
-  dom.window.document.body.appendChild(node);
+  const html = parseCitations(input);
+  dom.window.document.body.innerHTML = html;
   const groups = dom.window.document.querySelectorAll('.cite-group');
   assert.equal(groups.length, 1);
   assert.ok(dom.window.document.body.textContent.includes('{{Citation: "inner" SourceName: "N" SourceURL: "U" }}'));
 });
 
-test('script tags are rendered as text', () => {
+test('script tags are removed', () => {
   const dom = setupDom();
   const input = 'Bad <script>alert(1)</script> end';
-  const node = parseCitations(input);
-  dom.window.document.body.appendChild(node);
+  const html = parseCitations(input);
+  dom.window.document.body.innerHTML = html;
   assert.equal(dom.window.document.querySelector('script'), null);
-  assert.ok(dom.window.document.body.textContent.includes('<script>alert(1)</script>'));
+  assert.ok(!dom.window.document.body.textContent.includes('alert(1)'));
 });
-


### PR DESCRIPTION
## Summary
- allow sanitized HTML in location details
- sanitize citation parsing with DOMPurify
- load DOMPurify and add test coverage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2158cbb248330a90c70a649193a61