### PR TITLE
Add site icon with dark mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Online eFoil Guide
+<h1>
+  <img src="data/img/site%20icon/icon_black.svg#gh-light-mode-only" alt="eFoil Guide icon" width="40" />
+  <img src="data/img/site%20icon/icon_white.svg#gh-dark-mode-only" alt="eFoil Guide icon" width="40" />
+  Online eFoil Guide
+</h1>
 
 A community‑maintained directory of eFoil spots. The site loads all location data from [`data/locations.csv`](data/locations.csv) and renders it in a filterable table and map.
 If you’re just looking for spot information, head to https://byterookie.github.io/Efoilguide/; the sections below are for contributors.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-<h1>
+<h1 style="display:flex;align-items:center;gap:8px;">
   <img src="data/img/site%20icon/icon_black.svg#gh-light-mode-only" alt="eFoil Guide icon" width="40" />
   <img src="data/img/site%20icon/icon_white.svg#gh-dark-mode-only" alt="eFoil Guide icon" width="40" />
-  Online eFoil Guide
+  <span style="display:inline-block;line-height:1;text-align:center;">
+    <span style="font-size:60%;display:block;">eFoil</span>
+    <span style="display:block;">Guide</span>
+  </span>
 </h1>
 
 A community‑maintained directory of eFoil spots. The site loads all location data from [`data/locations.csv`](data/locations.csv) and renders it in a filterable table and map.

--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -38,9 +38,6 @@
 h1{margin:0;font-weight:800;font-size:clamp(20px,4vw,32px);line-height:1}
 header h1{cursor:pointer;display:flex;align-items:center;gap:8px}
 header h1 .logo{height:64px;width:64px}
-header h1 .title{position:relative;display:inline-block;line-height:1;text-align:center}
-header h1 .title .guide{display:block;font-size:1em}
-header h1 .title .efoil{position:absolute;bottom:100%;left:0;width:100%;font-size:.6em}
 .header-row{display:grid;grid-template-columns:auto 1fr auto;align-items:center;column-gap:25px;padding:8px;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px)}
   .search-wrap{position:relative;justify-self:center;display:inline-flex;justify-content:center;width:min(50vw,100%)}
   .search-wrap ul{list-style:none;margin-top:4px;padding:0;position:absolute;top:100%;left:0;right:0;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);border:1px solid var(--table-border);border-radius:var(--radius);max-height:50vh;overflow:auto;z-index:70}

--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -38,9 +38,9 @@
 h1{margin:0;font-weight:800;font-size:clamp(20px,4vw,32px);line-height:1}
 header h1{cursor:pointer;display:flex;align-items:center;gap:8px}
 header h1 .logo{height:64px;width:64px}
-header h1 .title{display:flex;flex-direction:column;line-height:.9}
-header h1 .title .efoil{font-size:.6em}
-header h1 .title .guide{font-size:1em}
+header h1 .title{position:relative;display:inline-block;line-height:1;text-align:center}
+header h1 .title .guide{display:block;font-size:1em}
+header h1 .title .efoil{position:absolute;bottom:100%;left:0;width:100%;font-size:.6em}
 .header-row{display:grid;grid-template-columns:auto 1fr auto;align-items:center;column-gap:25px;padding:8px;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px)}
   .search-wrap{position:relative;justify-self:center;display:inline-flex;justify-content:center;width:min(50vw,100%)}
   .search-wrap ul{list-style:none;margin-top:4px;padding:0;position:absolute;top:100%;left:0;right:0;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);border:1px solid var(--table-border);border-radius:var(--radius);max-height:50vh;overflow:auto;z-index:70}

--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -35,9 +35,12 @@
   .wrap{max-width:1200px;margin:auto;padding:clamp(16px,4vw,32px)}
   header .wrap{max-width:none;margin:0;padding:0}
   main.wrap{padding-top:0}
-h1{margin:0;font-weight:800;font-size:clamp(24px,4vw,40px);white-space:nowrap;line-height:48px;height:48px}
+h1{margin:0;font-weight:800;font-size:clamp(20px,4vw,32px);line-height:1}
 header h1{cursor:pointer;display:flex;align-items:center;gap:8px}
-header h1 .logo{height:48px;width:48px}
+header h1 .logo{height:64px;width:64px}
+header h1 .title{display:flex;flex-direction:column;line-height:.9}
+header h1 .title .efoil{font-size:.6em}
+header h1 .title .guide{font-size:1em}
 .header-row{display:grid;grid-template-columns:auto 1fr auto;align-items:center;column-gap:25px;padding:8px;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px)}
   .search-wrap{position:relative;justify-self:center;display:inline-flex;justify-content:center;width:min(50vw,100%)}
   .search-wrap ul{list-style:none;margin-top:4px;padding:0;position:absolute;top:100%;left:0;right:0;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);border:1px solid var(--table-border);border-radius:var(--radius);max-height:50vh;overflow:auto;z-index:70}
@@ -192,10 +195,11 @@ header h1 .logo{height:48px;width:48px}
       pointer-events:none;
     }
 @media (max-width:600px){
-  h1{line-height:40px;height:40px;font-size:clamp(20px,5vw,28px)}
-  .settings{height:40px}
-  .settings button{width:40px;height:40px;font-size:20px}
-  #q{height:40px}
+  h1{font-size:clamp(18px,5vw,28px)}
+  header h1 .logo{height:48px;width:48px}
+  .settings{height:48px}
+  .settings button{width:48px;height:48px;font-size:24px}
+  #q{height:48px}
 }
   #mins{flex:1}
 

--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -35,9 +35,10 @@
   .wrap{max-width:1200px;margin:auto;padding:clamp(16px,4vw,32px)}
   header .wrap{max-width:none;margin:0;padding:0}
   main.wrap{padding-top:0}
-  h1{margin:0;font-weight:800;font-size:clamp(24px,4vw,40px);white-space:nowrap;line-height:48px;height:48px}
-  header h1{cursor:pointer}
-  .header-row{display:grid;grid-template-columns:auto 1fr auto;align-items:center;column-gap:25px;padding:8px;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px)}
+h1{margin:0;font-weight:800;font-size:clamp(24px,4vw,40px);white-space:nowrap;line-height:48px;height:48px}
+header h1{cursor:pointer;display:flex;align-items:center;gap:8px}
+header h1 .logo{height:48px;width:48px}
+.header-row{display:grid;grid-template-columns:auto 1fr auto;align-items:center;column-gap:25px;padding:8px;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px)}
   .search-wrap{position:relative;justify-self:center;display:inline-flex;justify-content:center;width:min(50vw,100%)}
   .search-wrap ul{list-style:none;margin-top:4px;padding:0;position:absolute;top:100%;left:0;right:0;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);border:1px solid var(--table-border);border-radius:var(--radius);max-height:50vh;overflow:auto;z-index:70}
   .search-wrap li{padding:6px 8px;cursor:pointer}

--- a/index.html
+++ b/index.html
@@ -7,13 +7,22 @@
 <link rel="stylesheet" href="css/style.1.0.0.css">
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ctext x='0' y='14'%3E%E2%9A%93%3C/text%3E%3C/svg%3E">
+<link rel="icon" type="image/png" sizes="32x32" href="data/img/site%20icon/favicon-black-32x32.png" media="(prefers-color-scheme: light)">
+<link rel="icon" type="image/png" sizes="16x16" href="data/img/site%20icon/favicon-black-16x16.png" media="(prefers-color-scheme: light)">
+<link rel="icon" type="image/png" sizes="32x32" href="data/img/site%20icon/favicon-white-32x32.png" media="(prefers-color-scheme: dark)">
+<link rel="icon" type="image/png" sizes="16x16" href="data/img/site%20icon/favicon-white-16x16.png" media="(prefers-color-scheme: dark)">
 </head>
 <body>
 <header>
   <div class="wrap">
     <div class="header-row">
-      <h1>eFoil Guide</h1>
+      <h1>
+        <picture>
+          <source srcset="data/img/site%20icon/icon_white.svg" media="(prefers-color-scheme: dark)">
+          <img src="data/img/site%20icon/icon_black.svg" alt="" class="logo" />
+        </picture>
+        eFoil Guide
+      </h1>
       <div class="search-wrap">
         <input id="q" placeholder="Search all details" aria-label="Search spots" />
         <button id="qClear" class="hidden" aria-label="Clear search">✕</button>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
           <source srcset="data/img/site%20icon/icon_white.svg" media="(prefers-color-scheme: dark)">
           <img src="data/img/site%20icon/icon_black.svg" alt="" class="logo" />
         </picture>
-        eFoil Guide
+        <span class="title"><span class="efoil">eFoil</span><span class="guide">Guide</span></span>
       </h1>
       <div class="search-wrap">
         <input id="q" placeholder="Search all details" aria-label="Search spots" />

--- a/index.html
+++ b/index.html
@@ -19,9 +19,8 @@
       <h1>
         <picture>
           <source srcset="data/img/site%20icon/icon_white.svg" media="(prefers-color-scheme: dark)">
-          <img src="data/img/site%20icon/icon_black.svg" alt="" class="logo" />
+          <img src="data/img/site%20icon/icon_black.svg" alt="eFoil Guide" class="logo" />
         </picture>
-        <span class="title"><span class="guide">Guide</span><span class="efoil">eFoil</span></span>
       </h1>
       <div class="search-wrap">
         <input id="q" placeholder="Search all details" aria-label="Search spots" />

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
           <source srcset="data/img/site%20icon/icon_white.svg" media="(prefers-color-scheme: dark)">
           <img src="data/img/site%20icon/icon_black.svg" alt="" class="logo" />
         </picture>
-        <span class="title"><span class="efoil">eFoil</span><span class="guide">Guide</span></span>
+        <span class="title"><span class="guide">Guide</span><span class="efoil">eFoil</span></span>
       </h1>
       <div class="search-wrap">
         <input id="q" placeholder="Search all details" aria-label="Search spots" />


### PR DESCRIPTION
## Summary
- Replace inline emoji favicon with site icon files for light and dark browser themes
- Show site icon before "eFoil Guide" heading and include it in README title
- Style header to align logo and text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a220c678848330b385f2445a9afe3a