### PR TITLE
fix: remove top-level await causing load failure

### DIFF
--- a/js/main.1.0.0.js
+++ b/js/main.1.0.0.js
@@ -1600,7 +1600,9 @@ zip.addEventListener('input', async () => {
     updateSelectedTopPadding();
     updatePanelIcon();
     updateSheetIcon();
+
   });
+
     SPOTS = await loadSpots();
     await loadImageCredits();
     render();
@@ -1612,15 +1614,6 @@ zip.addEventListener('input', async () => {
 
     window.addEventListener('scroll', checkShrink);
   });
-
-  SPOTS = await loadSpots();
-  await loadImageCredits();
-  render();
-  initMap();
-  applyFilters();
-
-  window.addEventListener('scroll', checkShrink);
-});
 
 if (typeof module !== 'undefined') {
   module.exports = { detail, rowHTML };


### PR DESCRIPTION
## Summary
- fix DOMContentLoaded setup by closing geolocation click handler
- drop stray duplicate initialization to prevent top-level await error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a22bfbe62483308dc395ef296f3f28