### PR TITLE
Keep location dialog open and recenter map on new origin

### DIFF
--- a/js/main.1.0.0.js
+++ b/js/main.1.0.0.js
@@ -742,6 +742,7 @@ function clearSelected(){
   }
   updateOtherMarkers();
   hideOthers = false;
+  updateMapView();
 }
 
 function setMarkerSelected(marker, sel){
@@ -1194,11 +1195,8 @@ function setOrigin(lat,lng,label){
   originMsg.textContent = `Origin set to ${label}. Table sorted by nearest distance & ETA.`;
   render();
   initMap();
-  if(locationBox){
-    locationBox.classList.add('hidden');
-    if(editLocation) editLocation.classList.remove('active');
-    handleResize();
-  }
+  updateMapView();
+  handleResize();
 }
   document.addEventListener('DOMContentLoaded', async () => {
     originMsg = document.getElementById('originMsg');
@@ -1427,6 +1425,7 @@ function setOrigin(lat,lng,label){
           applyFilters();
         }
         updateOtherMarkers();
+        updateMapView();
       });
     }
 


### PR DESCRIPTION
## Summary
- Keep location popup open after setting origin
- Recenter map to chosen origin with slider-based zoom
- Reset map to origin when closing selections or clicking site logo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a23cdd3b888330a3a44312f2b3b795