### PR TITLE
Expand touch targets for panel resizing

### DIFF
--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -223,14 +223,14 @@ header h1 .logo{height:64px;width:64px}
 #map{position:fixed;top:0;left:0;right:0;bottom:0;z-index:0;}
 #tablePanel{position:fixed;top:calc(var(--header-h) + 8px);left:0;width:var(--panel-w);height:calc(100% - var(--header-h) - 8px);background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);transform:translateX(-100%);transition:transform .3s;z-index:40;border:1px solid var(--table-border);border-left:none;border-top-right-radius:var(--radius);border-bottom-right-radius:var(--radius);padding-top:0;overflow:hidden;display:flex;flex-direction:column;}
 #tablePanel.open{transform:translateX(0);}
-#panelGrip{position:absolute;top:0;right:0;width:8px;height:100%;cursor:col-resize}
+#panelGrip{position:absolute;top:0;right:0;width:20px;height:100%;cursor:col-resize;touch-action:none}
 #panelButtons{position:absolute;top:0;right:0;display:flex;gap:4px;z-index:5;background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);padding:4px;border-radius:0 var(--radius) 0 4px;padding-bottom:8px}
 #selectedButtons{position:absolute;top:0;right:0;display:flex;gap:4px;z-index:5;padding:4px}
 #panelButtons button,#selectedButtons button{background:none;border:none;color:var(--muted);cursor:pointer;padding:4px;font-size:20px}
 #selectedWrap{position:fixed;left:0;top:0;width:440px;max-width:100%;z-index:60;transform:translateY(100%);transition:transform .3s,width .3s;border-top-right-radius:var(--radius);border-bottom-right-radius:var(--radius);overflow:hidden;border:1px solid var(--table-border);background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);display:flex;flex-direction:column;}
 #selectedWrap.show{transform:translateY(0);}
-#sheetWidthGrip{position:absolute;top:0;right:0;width:8px;height:100%;cursor:col-resize;}
-#sheetHeightGrip{position:absolute;bottom:0;left:0;width:100%;height:8px;cursor:row-resize;}
+#sheetWidthGrip{position:absolute;top:0;right:0;width:20px;height:100%;cursor:col-resize;touch-action:none}
+#sheetHeightGrip{position:absolute;bottom:0;left:0;width:100%;height:20px;cursor:row-resize;touch-action:none}
 #selectedTop{background:linear-gradient(180deg,var(--header-grad1),var(--header-grad2));backdrop-filter:saturate(1.2) blur(8px);display:flex;align-items:center;position:relative;min-height:40px;padding:0;}
 #selectedTop::after{content:"";position:absolute;left:0;right:0;bottom:0;height:1px;background:var(--table-border);z-index:6;}
 #selectedTopScroll{flex:1;overflow-x:auto;-webkit-overflow-scrolling:touch;margin-right:0;}


### PR DESCRIPTION
## Summary
- Widen panel and sheet resize grips to 20px
- Disable default touch actions on resize grips for smoother dragging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a23e4bed04833096e459698e6b9ec2