### PR TITLE
Add ETA tooltip to distance header

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
         <thead>
           <tr>
             <th class="sortable" data-sort="name">Spot</th>
-            <th class="sortable" data-sort="dist" aria-sort="ascending">Dist / Time <span id="sortArrow">⇅</span></th>
+            <th class="sortable" data-sort="dist" aria-sort="ascending" title="ETAs use a simple urban/highway model; check your nav app for exact routing.">Dist / Time <span id="sortArrow">⇅</span></th>
             <th class="sortable" data-sort="water">Water</th>
             <th class="sortable" data-sort="season">Season</th>
             <th class="sortable" data-sort="skill">Skill</th>
@@ -119,7 +119,6 @@
     <div id="sheetWidthGrip"></div>
     <div id="sheetHeightGrip"></div>
   </div>
-  <p class="foot">ETAs use a simple urban/highway model; check your nav app for exact routing.</p>
 </main>
 
 <footer id="siteFooter">© <a href="https://github.com/byterookie" target="_blank">byterookie</a> <span id="year"></span> — This guide summarizes practical rules. Local postings and harbor patrol instructions always take precedence.</footer>


### PR DESCRIPTION
## Summary
- move ETA calculation note from page footer to Dist / Time header tooltip

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a240987eb88330951edc0711183eb6