### PR TITLE
Adjust distance column and bottom sheet behavior

### DIFF
--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -147,7 +147,7 @@ header h1 .logo{height:64px;width:64px}
     .detail-label .icon{font-size:14px}
     .detail-value{font-size:14px;margin-top:4px;display:flex;flex-wrap:wrap;gap:4px}
     .tip-wrap{position:relative;display:inline-block}
-    th .tip-wrap{margin-right:2px}
+    th .tip-wrap{position:absolute;left:0;top:50%;transform:translateY(-50%)}
     .info-btn{background:none;border:none;padding:0;color:var(--muted);cursor:pointer;display:flex;align-items:center}
     .info-btn svg{display:block;width:12px;height:12px}
     .tooltip-box{position:fixed;top:0;left:0;transform:translateY(-50%);background:var(--card);border:1px solid var(--control-border);border-radius:var(--radius);padding:8px 12px;font-size:13px;line-height:1.4;z-index:1000;display:block;width:300px;white-space:normal}

--- a/css/style.1.0.0.css
+++ b/css/style.1.0.0.css
@@ -85,8 +85,8 @@ header h1 .logo{height:64px;width:64px}
   .table-wrap table{width:100%;min-width:600px;border-collapse:separate;border-spacing:0;background:transparent;table-layout:fixed}
   .table-wrap thead{position:sticky;top:0;z-index:2;background:var(--panel-card)}
   .table-wrap thead th{white-space:nowrap}
-  .c-name{width:35%}
-  .c-dist{width:15%}
+  .c-name{width:32%}
+  .c-dist{width:18%}
   .c-water{width:15%}
   .c-season{width:20%}
   .c-skill{width:15%}
@@ -147,7 +147,7 @@ header h1 .logo{height:64px;width:64px}
     .detail-label .icon{font-size:14px}
     .detail-value{font-size:14px;margin-top:4px;display:flex;flex-wrap:wrap;gap:4px}
     .tip-wrap{position:relative;display:inline-block}
-    th .tip-wrap{margin-right:4px}
+    th .tip-wrap{margin-right:2px}
     .info-btn{background:none;border:none;padding:0;color:var(--muted);cursor:pointer;display:flex;align-items:center}
     .info-btn svg{display:block;width:12px;height:12px}
     .tooltip-box{position:fixed;top:0;left:0;transform:translateY(-50%);background:var(--card);border:1px solid var(--control-border);border-radius:var(--radius);padding:8px 12px;font-size:13px;line-height:1.4;z-index:1000;display:block;width:300px;white-space:normal}

--- a/js/main.1.0.0.js
+++ b/js/main.1.0.0.js
@@ -282,8 +282,8 @@ function isSheetDefault(){
   if(!selectedWrap) return true;
   const isMobile = window.innerWidth <= 700;
   const defaultW = isMobile ? window.innerWidth : SHEET_DEFAULT_W;
-  const defaultOffset = isMobile ? 0 : (headerEl ? headerEl.offsetHeight : 0) + SHEET_MARGIN;
-  const defaultFull = isMobile;
+  const defaultOffset = isMobile ? Math.round(window.innerHeight * 0.25) : (headerEl ? headerEl.offsetHeight : 0) + SHEET_MARGIN;
+  const defaultFull = false;
   return sheetFull === defaultFull &&
     Math.abs(selectedWrap.clientWidth - defaultW) < 2 &&
     Math.abs(sheetOffset - defaultOffset) < 2;
@@ -324,7 +324,7 @@ function handleResize(){
       sheetOffset = 0;
     }else if(isMobile){
       selectedWrap.style.width = '100%';
-      const min = (headerEl ? headerEl.offsetHeight : 0) + SHEET_MARGIN;
+      const min = 0;
       if(sheetOffset < min) sheetOffset = min;
     }else if(!selectedWrap.style.width || selectedWrap.style.width === '100%'){
       selectedWrap.style.width = SHEET_DEFAULT_W + 'px';
@@ -364,7 +364,7 @@ function togglePanelSize(){
 function toggleSheetSize(){
   if(!selectedWrap) return;
   const isMobile = window.innerWidth <= 700;
-  const defaultOffset = (headerEl ? headerEl.offsetHeight : 0) + SHEET_MARGIN;
+  const defaultOffset = isMobile ? Math.round(window.innerHeight * 0.25) : (headerEl ? headerEl.offsetHeight : 0) + SHEET_MARGIN;
   if(sheetFull || !isSheetDefault()){
     sheetFull = false;
     sheetOffset = defaultOffset;
@@ -774,10 +774,10 @@ function showSelected(s, fromList=false){
   selectedWrap.classList.remove('hidden');
   selectedWrap.setAttribute('aria-hidden','false');
   const isMobile = window.innerWidth <= 700;
-  sheetFull = isMobile;
+  sheetFull = false;
   if(isMobile){
     selectedWrap.style.width = '100%';
-    sheetOffset = 0;
+    sheetOffset = Math.round(window.innerHeight * 0.25);
   }else{
     selectedWrap.style.width = SHEET_DEFAULT_W + 'px';
     sheetOffset = (headerEl ? headerEl.offsetHeight : 0) + SHEET_MARGIN;


### PR DESCRIPTION
## Summary
- Widen distance column and trim tooltip spacing to avoid header overlap
- Load spot detail sheet at 75% height on mobile and expand to full-screen above menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a359839a3483309ab3a051aa4d0d1e